### PR TITLE
feat(cli): according to documentation, rename http-server option to serve-front

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -89,7 +89,12 @@ program
     () => true,
     false,
   )
-  .option('-h, --http-server', 'Run local http server', () => true, false)
+  .option(
+    '--serve-front',
+    'Run local http server to serve your front code',
+    () => true,
+    false,
+  )
   .description('Run your code')
   .action((command) =>
     createApp(command)

--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -109,7 +109,7 @@ const run = (command, config, declaration) => {
           });
       });
       info('Worker is up!');
-      if (command.httpServer) {
+      if (command.serveFront) {
         return createServer(command, config);
       }
     })


### PR DESCRIPTION
affects: @zetapush/cli

BREAKING CHANGE:
rename http-server option to serve-front

ISSUES CLOSED: #55

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Option to serve front is --http-server


**What is the new behavior?**
Option to serve front is --serve-front

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: