### PR TITLE
feat(create): set node typings as dependency instead of dev dependency

### DIFF
--- a/packages/create/createApp.js
+++ b/packages/create/createApp.js
@@ -114,8 +114,7 @@ function createApp(name, zetarc, version, command) {
       start: 'zeta run',
       troubleshoot: 'zeta troubleshoot'
     },
-    dependencies: {},
-    devDependencies: {}
+    dependencies: {}
   };
   // Create package.json
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson, null, 2) + os.EOL);
@@ -248,21 +247,18 @@ function init(appPath, appName, originalDirectory, command) {
 function run(root, appName, originalDirectory, version, command) {
   const versionStr = version ? '@' + version : '';
   const dependencies = [
+    `@types/node@10`,
     `@zetapush/core${versionStr}`,
     `@zetapush/cli${versionStr}`,
     `@zetapush/platform-legacy${versionStr}`,
     `typescript@latest`
   ];
-  const devDependencies = [
-    `@types/node`
-  ]
 
   console.log('Installing packages. This might take a couple of minutes.');
   console.log(`Installing ${dependencies.map((dependency) => `${chalk.cyan(dependency)}`).join(', ')}.`);
-  console.log(`Installing ${devDependencies.map((dependency) => `${chalk.cyan(dependency)}`).join(', ')}.`);
   console.log();
 
-  return install(dependencies, devDependencies)
+  return install(dependencies)
     .then(() => init(root, appName, originalDirectory, command))
     .catch((reason) => {
       console.log();
@@ -300,47 +296,23 @@ function run(root, appName, originalDirectory, version, command) {
 }
 
 /**
- * Install all dependencies in the same time (runtime and dev dependencies)
+ * Install all dependencies
  * @param {*} dependencies 
- * @param {*} devDependencies 
  */
-function install(dependencies, devDependencies) {
+function install(dependencies) {
   const command = 'npm';
   const args = ['install', '--save', '--save-exact', '--loglevel', 'error'].concat(dependencies);
-  const argsDev = ['install', '--save-dev', '--save-exact', '--loglevel', 'error'].concat(devDependencies);
 
-  const installDependencies = new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const child = spawn(command, args, { stdio: 'inherit' });
     child.on('close', (code) => {
       if (code !== 0) {
-        reject({
+        return reject({
           command: `${command} ${args.join(' ')}`
         });
-        return;
       }
       resolve();
     });
-  });
-
-  const installDevDependencies = new Promise((resolve, reject) => {
-    const child = spawn(command, argsDev, { stdio: 'inherit' });
-    child.on('close', (code) => {
-      if (code !== 0) {
-        reject({
-          command: `${command} ${args.join(' ')}`
-        });
-        return;
-      }
-      resolve();
-    });
-  });
-
-  return new Promise((resolve, reject) => {
-    Promise.all([installDependencies, installDevDependencies]).then((res) => {
-      resolve(res);
-    }).catch((err) => {
-      reject(err);
-    })
   });
 }
 


### PR DESCRIPTION
affects: @zetapush/create

ISSUES CLOSED: #131

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Node typings are installed as dev dependency so when worker is started in production env ts-node crash due to missing typings.

**What is the new behavior?**
Node typings are installed as dependency

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: