### PR TITLE
fix(namespace): test client handles new namespace format

### DIFF
--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@zetapush/integration",
+  "version": "0.33.1",
   "private": true,
   "scripts": {
     "test": "jasmine"
@@ -10,7 +11,7 @@
     "toxy": "^0.3.15"
   },
   "devDependencies": {
-    "@zetapush/testing": "0.32.0",
+    "@zetapush/testing": "0.33.1",
     "jasmine": "3.1.0",
     "jasmine-reporters": "2.3.1"
   }

--- a/packages/integration/spec/account/account-not-validated.spec.js
+++ b/packages/integration/spec/account/account-not-validated.spec.js
@@ -1,5 +1,5 @@
 const { zetaPush, zetaRun } = require('@zetapush/testing');
-const { given, consoleUserAction } = require('@zetapush/testing');
+const { given, consoleAction } = require('@zetapush/testing');
 
 describe(`As developer with
         - account not validated
@@ -23,7 +23,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-05' (55) for 'zeta push'",
     async () => {
-      await consoleUserAction('zeta push', async () => {
+      await consoleAction('zeta push', async () => {
         const { code } = await zetaPush(this.context.projectDir);
         expect(code).toBe(errorCode);
       });
@@ -34,7 +34,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-05' (55) for 'zeta run'",
     async () => {
-      await consoleUserAction('zeta run', async () => {
+      await consoleAction('zeta run', async () => {
         const { code } = await zetaRun(this.context.projectDir);
         expect(code).toBe(errorCode);
       });

--- a/packages/integration/spec/account/no-account.spec.js
+++ b/packages/integration/spec/account/no-account.spec.js
@@ -1,5 +1,5 @@
 const { zetaPush, zetaRun } = require('@zetapush/testing');
-const { given, consoleUserAction } = require('@zetapush/testing');
+const { given, consoleAction } = require('@zetapush/testing');
 
 describe(`As developer with
         - account doesn't exists
@@ -23,7 +23,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-03' (53) for 'zeta push'",
     async () => {
-      await consoleUserAction('zeta push', async () => {
+      await consoleAction('zeta push', async () => {
         const { code } = await zetaPush(this.context.projectDir);
         expect(code).toBe(errorCode);
       });
@@ -34,7 +34,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-03' (53) for 'zeta run'",
     async () => {
-      await consoleUserAction('zeta run', async () => {
+      await consoleAction('zeta run', async () => {
         const { code } = await zetaRun(this.context.projectDir);
         expect(code).toBe(errorCode);
       });

--- a/packages/integration/spec/account/no-appname.spec.js
+++ b/packages/integration/spec/account/no-appname.spec.js
@@ -1,6 +1,6 @@
 const { zetaPush, readZetarc } = require('@zetapush/testing');
 const PATTERN = /Hello World from JavaScript (\d+)/;
-const { given, consoleUserAction, frontUserAction, autoclean } = require('@zetapush/testing');
+const { given, consoleAction, frontAction, autoclean } = require('@zetapush/testing');
 
 describe(`As developer with
         - account exists
@@ -27,7 +27,7 @@ describe(`As developer with
         /**/ .apply(this);
 
       // zeta push
-      await consoleUserAction('1) zeta push', async () => {
+      await consoleAction('1) zeta push', async () => {
         await zetaPush(this.context.projectDir);
       });
 
@@ -38,9 +38,8 @@ describe(`As developer with
       expect(zetarc.appName).toBeDefined();
       expect(zetarc.appName.length).toBeGreaterThan(0);
 
-      await frontUserAction()
+      await frontAction(this)
         .name('2) call hello')
-        .context(this)
         .execute(async (api) => {
           const message = await api.hello();
           expect(typeof message).toBe('string');

--- a/packages/integration/spec/account/no-appname.spec.js
+++ b/packages/integration/spec/account/no-appname.spec.js
@@ -38,11 +38,14 @@ describe(`As developer with
       expect(zetarc.appName).toBeDefined();
       expect(zetarc.appName.length).toBeGreaterThan(0);
 
-      await frontUserAction('2) call hello', this, async (api) => {
-        const message = await api.hello();
-        expect(typeof message).toBe('string');
-        expect(PATTERN.test(message)).toBe(true);
-      });
+      await frontUserAction()
+        .name('2) call hello')
+        .context(this)
+        .execute(async (api) => {
+          const message = await api.hello();
+          expect(typeof message).toBe('string');
+          expect(PATTERN.test(message)).toBe(true);
+        });
     },
     15 * 60 * 1000
   );

--- a/packages/integration/spec/account/no-login.spec.js
+++ b/packages/integration/spec/account/no-login.spec.js
@@ -1,5 +1,5 @@
 const { zetaPush, zetaRun } = require('@zetapush/testing');
-const { given, consoleUserAction } = require('@zetapush/testing');
+const { given, consoleAction } = require('@zetapush/testing');
 
 describe(`As developer with
         - no developerLogin
@@ -23,7 +23,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-01' (51) for 'zeta push'",
     async () => {
-      await consoleUserAction('zeta push', async () => {
+      await consoleAction('zeta push', async () => {
         const { code } = await zetaPush(this.context.projectDir);
         expect(code).toBe(errorCode);
       });
@@ -34,7 +34,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-01' (51) for 'zeta run'",
     async () => {
-      await consoleUserAction('zeta run', async () => {
+      await consoleAction('zeta run', async () => {
         const { code } = await zetaRun(this.context.projectDir);
         expect(code).toBe(errorCode);
       });

--- a/packages/integration/spec/account/no-password.spec.js
+++ b/packages/integration/spec/account/no-password.spec.js
@@ -1,5 +1,5 @@
 const { zetaPush, zetaRun } = require('@zetapush/testing');
-const { given, consoleUserAction } = require('@zetapush/testing');
+const { given, consoleAction } = require('@zetapush/testing');
 
 describe(`As developer with
         - no developerPassword
@@ -23,7 +23,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-02' (52) for 'zeta push'",
     async () => {
-      await consoleUserAction('zeta push', async () => {
+      await consoleAction('zeta push', async () => {
         const { code } = await zetaPush(this.context.projectDir);
         expect(code).toBe(errorCode);
       });
@@ -34,7 +34,7 @@ describe(`As developer with
   it(
     "Should fail with errorCode 'ACCOUNT-02' (52) for 'zeta run'",
     async () => {
-      await consoleUserAction('zeta run', async () => {
+      await consoleAction('zeta run', async () => {
         const { code } = await zetaRun(this.context.projectDir);
         expect(code).toBe(errorCode);
       });

--- a/packages/integration/spec/nominal.spec.js
+++ b/packages/integration/spec/nominal.spec.js
@@ -1,5 +1,5 @@
 const { rm, npmInit, zetaPush, readZetarc, nukeProject } = require('@zetapush/testing');
-const { consoleUserAction, frontUserAction } = require('@zetapush/testing');
+const { consoleAction, frontAction } = require('@zetapush/testing');
 const PATTERN = /Hello World from JavaScript (\d+)/;
 
 describe(`As developer with
@@ -31,12 +31,12 @@ describe(`As developer with
       - use published hello-world custom cloud services`,
     async () => {
       // 1) npm init
-      await consoleUserAction('1) npm init', async () => {
+      await consoleAction('1) npm init', async () => {
         await npmInit(this.developerLogin, this.developerPassword, fullPathProject, this.platformUrl);
       });
 
       // 2) zeta push
-      await consoleUserAction('2) zeta push', async () => {
+      await consoleAction('2) zeta push', async () => {
         await zetaPush(fullPathProject);
       });
 
@@ -48,9 +48,8 @@ describe(`As developer with
       expect(zetarc.developerPassword).toBe(this.developerPassword);
 
       // 3) check using a client
-      await frontUserAction()
+      await frontAction({ zetarc })
         .name('3) call worker')
-        .context({ zetarc })
         .execute(async (api) => {
           const message = await api.hello();
           expect(typeof message).toBe('string');

--- a/packages/integration/spec/nominal.spec.js
+++ b/packages/integration/spec/nominal.spec.js
@@ -48,11 +48,14 @@ describe(`As developer with
       expect(zetarc.developerPassword).toBe(this.developerPassword);
 
       // 3) check using a client
-      await frontUserAction('3) call worker', { zetarc }, async (api) => {
-        const message = await api.hello();
-        expect(typeof message).toBe('string');
-        expect(PATTERN.test(message)).toBe(true);
-      });
+      await frontUserAction()
+        .name('3) call worker')
+        .context({ zetarc })
+        .execute(async (api) => {
+          const message = await api.hello();
+          expect(typeof message).toBe('string');
+          expect(PATTERN.test(message)).toBe(true);
+        });
     },
     20 * 60 * 1000
   );

--- a/packages/integration/spec/runtime.spec.js
+++ b/packages/integration/spec/runtime.spec.js
@@ -33,16 +33,19 @@ describe(`As developer with
         /*   */ .and()
         /**/ .apply(this);
 
-      await frontUserAction('call hello', this, async (api) => {
-        let failure = false;
-        try {
-          await api.hello();
-        } catch (error) {
-          failure = true;
-        }
-        await this.context.runner.stop();
-        expect(failure).toBe(false);
-      });
+      await frontUserAction()
+        .name('call hello')
+        .context(this)
+        .execute(async (api) => {
+          let failure = false;
+          try {
+            await api.hello();
+          } catch (error) {
+            failure = true;
+          }
+          await this.context.runner.stop();
+          expect(failure).toBe(false);
+        });
     },
     60 * 1000 * 10
   );
@@ -68,16 +71,19 @@ describe(`As developer with
         /*   */ .and()
         /**/ .apply(this);
 
-      await frontUserAction('call hello', this, async (api) => {
-        let failure = false;
-        try {
-          await api.hello();
-        } catch (error) {
-          failure = true;
-        }
-        await this.context.runner.stop();
-        expect(failure).toBe(true);
-      });
+      await frontUserAction()
+        .name('call hello')
+        .context(this)
+        .execute(async (api) => {
+          let failure = false;
+          try {
+            await api.hello();
+          } catch (error) {
+            failure = true;
+          }
+          await this.context.runner.stop();
+          expect(failure).toBe(true);
+        });
     },
     60 * 1000 * 2
   );
@@ -136,19 +142,22 @@ describe(`As developer with
         /*   */ .and()
         /**/ .apply(this);
 
-      await frontUserAction('call hello', this, async (api) => {
-        let helloReceived = false;
-        const sendHello = async () => {
-          // hello function in worker exits the worker => no answer will be received so promise won't be resolved
-          await api.hello();
-          console.log('RECEIVED');
-          helloReceived = true;
-        };
-        sendHello();
-        await sleep(5000);
-        await this.context.runner.stop();
-        expect(helloReceived).toBe(false);
-      });
+      await frontUserAction()
+        .name('call hello')
+        .context(this)
+        .execute(async (api) => {
+          let helloReceived = false;
+          const sendHello = async () => {
+            // hello function in worker exits the worker => no answer will be received so promise won't be resolved
+            await api.hello();
+            console.log('RECEIVED');
+            helloReceived = true;
+          };
+          sendHello();
+          await sleep(5000);
+          await this.context.runner.stop();
+          expect(helloReceived).toBe(false);
+        });
     },
     60 * 1000 * 10
   );

--- a/packages/integration/spec/runtime.spec.js
+++ b/packages/integration/spec/runtime.spec.js
@@ -1,4 +1,4 @@
-const { given, frontUserAction, autoclean } = require('@zetapush/testing');
+const { given, frontAction, autoclean } = require('@zetapush/testing');
 
 const sleep = (millis) => {
   return new Promise((resolve) => setTimeout(resolve, millis));
@@ -33,9 +33,8 @@ describe(`As developer with
         /*   */ .and()
         /**/ .apply(this);
 
-      await frontUserAction()
+      await frontAction(this)
         .name('call hello')
-        .context(this)
         .execute(async (api) => {
           let failure = false;
           try {
@@ -71,9 +70,8 @@ describe(`As developer with
         /*   */ .and()
         /**/ .apply(this);
 
-      await frontUserAction()
+      await frontAction(this)
         .name('call hello')
-        .context(this)
         .execute(async (api) => {
           let failure = false;
           try {
@@ -142,9 +140,8 @@ describe(`As developer with
         /*   */ .and()
         /**/ .apply(this);
 
-      await frontUserAction()
+      await frontAction(this)
         .name('call hello')
-        .context(this)
         .execute(async (api) => {
           let helloReceived = false;
           const sendHello = async () => {

--- a/packages/integration/spec/user-management/default-standard-user-workflow.spec.js
+++ b/packages/integration/spec/user-management/default-standard-user-workflow.spec.js
@@ -35,17 +35,22 @@ describe(`As developer with
           /*  */ .and()
           /**/ .apply(this);
 
-        await frontUserAction(`Create the user account on the application`, this, async (api) => {
-          const userAccount = {
-            login: 'login',
-            password: 'password',
-            firstname: 'Firstname',
-            lastname: 'Lastname',
-            email: 'firstname.lastname@yopmail.com'
-          };
+        await frontUserAction()
+          .name(`Create the user account on the application`)
+          .context(this)
+          .api()
+          /**/ .namespace('user')
+          /**/ .and()
+          .execute(async (api) => {
+            const userAccount = {
+              login: 'login',
+              password: 'password',
+              firstname: 'Firstname',
+              lastname: 'Lastname',
+              email: 'firstname.lastname@yopmail.com'
+            };
 
-          resultOfSignUp = await api.signup(
-            {
+            resultOfSignUp = await api.signup({
               credentials: {
                 login: userAccount.login,
                 password: userAccount.password
@@ -55,28 +60,33 @@ describe(`As developer with
                 lastname: userAccount.lastname,
                 email: userAccount.email
               }
-            },
-            'user'
-          );
+            });
 
-          expect(resultOfSignUp.createdAccount.accountId).toBeDefined();
-          expect(resultOfSignUp.createdAccount.accountStatus).toEqual('WAITING_FOR_CONFIRMATION');
-          expect(resultOfSignUp.createdAccount.profile).toEqual({
-            firstname: 'Firstname',
-            lastname: 'Lastname',
-            email: 'firstname.lastname@yopmail.com'
+            expect(resultOfSignUp.createdAccount.accountId).toBeDefined();
+            expect(resultOfSignUp.createdAccount.accountStatus).toEqual('WAITING_FOR_CONFIRMATION');
+            expect(resultOfSignUp.createdAccount.profile).toEqual({
+              firstname: 'Firstname',
+              lastname: 'Lastname',
+              email: 'firstname.lastname@yopmail.com'
+            });
+            expect(resultOfSignUp.token.original.value).toBeDefined();
           });
-          expect(resultOfSignUp.token.original.value).toBeDefined();
-        });
 
-        await frontUserAction(`Validate the user account`, this, async (api) => {
-          resultOfConfirm = await api.confirm(resultOfSignUp, 'user');
-        });
+        await frontUserAction()
+          .name(`Validate the user account`)
+          .context(this)
+          .api()
+          /**/ .namespace('user')
+          /**/ .and()
+          .execute(async (api) => {
+            resultOfConfirm = await api.confirm(resultOfSignUp);
+          });
 
-        await frontUserAction(`Connection of the user on the application`, this, async (api, client) => {}, {
-          login: 'login',
-          password: 'password'
-        });
+        await frontUserAction()
+          .name(`Connection of the user on the application`)
+          .context(this)
+          .loggedAs('login', 'password')
+          .execute();
       },
       60 * 1000 * 10
     );
@@ -101,17 +111,22 @@ describe(`As developer with
           /*  */ .and()
           /**/ .apply(this);
 
-        await frontUserAction(`Create the user account on the application`, this, async (api) => {
-          const userAccount = {
-            login: 'login',
-            password: 'password',
-            firstname: 'Firstname',
-            lastname: 'Lastname',
-            email: 'firstname.lastname@yopmail.com'
-          };
+        await frontUserAction()
+          .name(`Create the user account on the application`)
+          .context(this)
+          .api()
+          /**/ .namespace('user')
+          /**/ .and()
+          .execute(async (api) => {
+            const userAccount = {
+              login: 'login',
+              password: 'password',
+              firstname: 'Firstname',
+              lastname: 'Lastname',
+              email: 'firstname.lastname@yopmail.com'
+            };
 
-          resultOfSignUp = await api.signup(
-            {
+            resultOfSignUp = await api.signup({
               credentials: {
                 login: userAccount.login,
                 password: userAccount.password
@@ -121,25 +136,24 @@ describe(`As developer with
                 lastname: userAccount.lastname,
                 email: userAccount.email
               }
-            },
-            'user'
-          );
+            });
 
-          expect(resultOfSignUp.createdAccount.accountId).toBeDefined();
-          expect(resultOfSignUp.createdAccount.accountStatus).toEqual('WAITING_FOR_CONFIRMATION');
-          expect(resultOfSignUp.createdAccount.profile).toEqual({
-            firstname: 'Firstname',
-            lastname: 'Lastname',
-            email: 'firstname.lastname@yopmail.com'
+            expect(resultOfSignUp.createdAccount.accountId).toBeDefined();
+            expect(resultOfSignUp.createdAccount.accountStatus).toEqual('WAITING_FOR_CONFIRMATION');
+            expect(resultOfSignUp.createdAccount.profile).toEqual({
+              firstname: 'Firstname',
+              lastname: 'Lastname',
+              email: 'firstname.lastname@yopmail.com'
+            });
+            expect(resultOfSignUp.token.original.value).toBeDefined();
           });
-          expect(resultOfSignUp.token.original.value).toBeDefined();
-        });
 
         try {
-          await frontUserAction(`Connection of the user on the application`, this, async (api, client) => {}, {
-            login: 'login',
-            password: 'password'
-          });
+          await frontUserAction()
+            .name(`Connection of the user on the application`)
+            .context(this)
+            .loggedAs('login', 'password')
+            .execute();
         } catch (e) {
           expect(e).toEqual('403::Handshake denied');
         }
@@ -167,17 +181,22 @@ describe(`As developer with
           /*  */ .and()
           /**/ .apply(this);
 
-        await frontUserAction(`Create the user account on the application`, this, async (api) => {
-          const userAccount = {
-            login: 'login',
-            password: 'password',
-            firstname: 'Firstname',
-            lastname: 'Lastname',
-            email: 'firstname.lastname@yopmail.com'
-          };
+        await frontUserAction()
+          .context(this)
+          .name(`Create the user account on the application`)
+          .api()
+          /**/ .namespace('user')
+          /**/ .and()
+          .execute(async (api) => {
+            const userAccount = {
+              login: 'login',
+              password: 'password',
+              firstname: 'Firstname',
+              lastname: 'Lastname',
+              email: 'firstname.lastname@yopmail.com'
+            };
 
-          resultOfSignUp = await api.signup(
-            {
+            resultOfSignUp = await api.signup({
               credentials: {
                 login: userAccount.login,
                 password: userAccount.password
@@ -187,29 +206,37 @@ describe(`As developer with
                 lastname: userAccount.lastname,
                 email: userAccount.email
               }
-            },
-            'user'
-          );
+            });
 
-          expect(resultOfSignUp.createdAccount.accountId).toBeDefined();
-          expect(resultOfSignUp.createdAccount.accountStatus).toEqual('WAITING_FOR_CONFIRMATION');
-          expect(resultOfSignUp.createdAccount.profile).toEqual({
-            firstname: 'Firstname',
-            lastname: 'Lastname',
-            email: 'firstname.lastname@yopmail.com'
+            expect(resultOfSignUp.createdAccount.accountId).toBeDefined();
+            expect(resultOfSignUp.createdAccount.accountStatus).toEqual('WAITING_FOR_CONFIRMATION');
+            expect(resultOfSignUp.createdAccount.profile).toEqual({
+              firstname: 'Firstname',
+              lastname: 'Lastname',
+              email: 'firstname.lastname@yopmail.com'
+            });
+            expect(resultOfSignUp.token.original.value).toBeDefined();
           });
-          expect(resultOfSignUp.token.original.value).toBeDefined();
-        });
 
-        await frontUserAction(`Validate the user account`, this, async (api) => {
-          resultOfConfirm = await api.confirm(resultOfSignUp, 'user');
-        });
+        await frontUserAction()
+          .context(this)
+          .name(`Validate the user account`)
+          .api()
+          /**/ .namespace('user')
+          /**/ .and()
+          .execute(async (api) => {
+            resultOfConfirm = await api.confirm(resultOfSignUp);
+          });
 
         try {
-          await frontUserAction(`Connection of the user on the application`, this, async (api, client) => {}, {
-            login: 'login',
-            password: 'wrong-password'
-          });
+          await frontUserAction()
+            .context(this)
+            .name(`Connection of the user on the application`)
+            .loggedAs('login', 'wrong-password')
+            .api()
+            /**/ .namespace('user')
+            /**/ .and()
+            .execute();
         } catch (e) {
           expect(e).toEqual('403::Handshake denied');
         }

--- a/packages/integration/spec/user-management/default-standard-user-workflow.spec.js
+++ b/packages/integration/spec/user-management/default-standard-user-workflow.spec.js
@@ -1,4 +1,4 @@
-const { given, autoclean, frontUserAction } = require('@zetapush/testing');
+const { given, autoclean, frontAction } = require('@zetapush/testing');
 
 describe(`As developer with
   - valid account
@@ -35,9 +35,8 @@ describe(`As developer with
           /*  */ .and()
           /**/ .apply(this);
 
-        await frontUserAction()
+        await frontAction(this)
           .name(`Create the user account on the application`)
-          .context(this)
           .api()
           /**/ .namespace('user')
           /**/ .and()
@@ -72,9 +71,8 @@ describe(`As developer with
             expect(resultOfSignUp.token.original.value).toBeDefined();
           });
 
-        await frontUserAction()
+        await frontAction(this)
           .name(`Validate the user account`)
-          .context(this)
           .api()
           /**/ .namespace('user')
           /**/ .and()
@@ -82,9 +80,8 @@ describe(`As developer with
             resultOfConfirm = await api.confirm(resultOfSignUp);
           });
 
-        await frontUserAction()
+        await frontAction(this)
           .name(`Connection of the user on the application`)
-          .context(this)
           .loggedAs('login', 'password')
           .execute();
       },
@@ -111,9 +108,8 @@ describe(`As developer with
           /*  */ .and()
           /**/ .apply(this);
 
-        await frontUserAction()
+        await frontAction(this)
           .name(`Create the user account on the application`)
-          .context(this)
           .api()
           /**/ .namespace('user')
           /**/ .and()
@@ -149,9 +145,8 @@ describe(`As developer with
           });
 
         try {
-          await frontUserAction()
+          await frontAction(this)
             .name(`Connection of the user on the application`)
-            .context(this)
             .loggedAs('login', 'password')
             .execute();
         } catch (e) {
@@ -181,8 +176,7 @@ describe(`As developer with
           /*  */ .and()
           /**/ .apply(this);
 
-        await frontUserAction()
-          .context(this)
+        await frontAction(this)
           .name(`Create the user account on the application`)
           .api()
           /**/ .namespace('user')
@@ -218,8 +212,7 @@ describe(`As developer with
             expect(resultOfSignUp.token.original.value).toBeDefined();
           });
 
-        await frontUserAction()
-          .context(this)
+        await frontAction(this)
           .name(`Validate the user account`)
           .api()
           /**/ .namespace('user')
@@ -229,8 +222,7 @@ describe(`As developer with
           });
 
         try {
-          await frontUserAction()
-            .context(this)
+          await frontAction(this)
             .name(`Connection of the user on the application`)
             .loggedAs('login', 'wrong-password')
             .api()

--- a/packages/testing/src/bdd/when.ts
+++ b/packages/testing/src/bdd/when.ts
@@ -1,4 +1,4 @@
-import { SmartClient } from '@zetapush/client';
+import { SmartClient, Client } from '@zetapush/client';
 import { ResolvedConfig, Service } from '@zetapush/common';
 import { FactoryProvider } from '@zetapush/core';
 import { WorkerRunner, WorkerRunnerEvents } from '@zetapush/worker';
@@ -33,45 +33,15 @@ export const consoleUserAction = async (name: string, func: () => any) => {
   return await userAction(name + ' from console', func);
 };
 
-export const frontUserAction = async (
-  name: string,
-  testOrContext: Context,
-  func: (api: any, client: SmartClient) => any,
-  credentials?: Credentials
-) => {
-  return await userAction(name + ' from front', async () => {
-    let api;
-    let client;
-    try {
-      const zetarc = new ContextWrapper(testOrContext).getContext().zetarc;
-      client = new SmartClient({
-        ...(<any>zetarc),
-        transports
-      });
-      frontUserActionLogger.debug('Connecting to worker...');
-      await client.disconnect();
-      if (credentials) {
-        await client.setCredentials(credentials);
-      }
-      const resu = await client.connect();
-      frontUserActionLogger.debug('Connected to worker');
-      api = (<any>client).createProxyTaskService();
-      frontUserActionLogger.debug('Api instance created');
-    } catch (e) {
-      frontUserActionLogger.error("Connection from client failed. Cloud service won't be called", e);
-      throw e;
-    }
-    try {
-      return await func(api, client);
-    } catch (e) {
-      frontUserActionLogger.error(
-        `>>> Front user action FAILED: ${name}`,
-        new ContextWrapper(testOrContext).getContext(),
-        e
-      );
-      throw e;
-    }
-  });
+export const frontUserAction = (name?: string, testOrContext?: Context) => {
+  const action = new UserAction();
+  if (name) {
+    action.name(name);
+  }
+  if (testOrContext) {
+    action.context(testOrContext);
+  }
+  return action;
 };
 
 export const runInWorker = (testOrContext: Context, workerDeclaration: (...instances: any[]) => void) => {
@@ -168,3 +138,108 @@ export const runInWorker = (testOrContext: Context, workerDeclaration: (...insta
     }
   });
 };
+
+class Parent<P> {
+  constructor(private parent: P) {}
+
+  and() {
+    return this.parent;
+  }
+}
+
+class UserAction {
+  private testOrContext?: Context;
+  private actionName: string = 'user action';
+  private actionNameSuffix: string = ' from front';
+  private credentials?: Credentials;
+  private apiBuilder?: Api;
+
+  constructor() {}
+
+  context(testOrContext: Context) {
+    this.testOrContext = testOrContext;
+    return this;
+  }
+
+  name(actionName: string, suffix = ' from front') {
+    this.actionName = actionName;
+    this.actionNameSuffix = suffix;
+    return this;
+  }
+
+  loggedAs(login: string, password: string): UserAction;
+  loggedAs(credentials: Credentials): UserAction;
+  loggedAs(loginOrCreds: any, password?: string): UserAction {
+    if (typeof loginOrCreds === 'string') {
+      this.credentials = { login: loginOrCreds, password: password || '' };
+      return this;
+    }
+    this.credentials = loginOrCreds;
+    return this;
+  }
+
+  api() {
+    this.apiBuilder = new Api(this);
+    return this.apiBuilder;
+  }
+
+  async execute(func?: (api: any, client: Client) => Promise<any>) {
+    return await userAction(this.actionName + this.actionNameSuffix, async () => {
+      let api;
+      let client;
+      try {
+        const zetarc = new ContextWrapper(this.testOrContext).getContext().zetarc;
+        client = new SmartClient({
+          ...(<any>zetarc),
+          transports
+        });
+        frontUserActionLogger.debug('Connecting to worker...');
+        await client.disconnect();
+        if (this.credentials) {
+          await client.setCredentials(this.credentials);
+        }
+        const resu = await client.connect();
+        frontUserActionLogger.debug('Connected to worker');
+        if (!this.apiBuilder) {
+          this.apiBuilder = new Api(this);
+        }
+        api = <any>this.apiBuilder.build(client);
+        frontUserActionLogger.debug('Api instance created');
+      } catch (e) {
+        frontUserActionLogger.error("Connection from client failed. Cloud service won't be called", e);
+        throw e;
+      }
+      try {
+        if (func) {
+          return await func(api, client);
+        }
+      } catch (e) {
+        frontUserActionLogger.error(
+          `>>> Front user action FAILED: ${this.actionName}`,
+          new ContextWrapper(this.testOrContext).getContext(),
+          e
+        );
+        throw e;
+      }
+    });
+  }
+}
+
+class Api extends Parent<UserAction> {
+  private apiNamespace?: string;
+  private apiCallTimeout?: number;
+
+  namespace(namespace: string) {
+    this.apiNamespace = namespace;
+    return this;
+  }
+
+  timeout(timeout: number) {
+    this.apiCallTimeout = timeout;
+    return this;
+  }
+
+  build(client: Client) {
+    return client.createProxyTaskService({ timeout: this.apiCallTimeout, namespace: this.apiNamespace });
+  }
+}

--- a/packages/testing/src/utils/logger.ts
+++ b/packages/testing/src/utils/logger.ts
@@ -90,7 +90,7 @@ export const addCategorizedLogger = (name: string, label: string, fmt?: string) 
 
 export const givenLogger = addCategorizedLogger('given', 'GIVEN', 'grey');
 export const userActionLogger = addCategorizedLogger('userAction', 'USER ACTION', 'bold');
-export const frontUserActionLogger = addCategorizedLogger('frontUserAction', 'FRONT USER ACTION', 'bold');
+export const frontActionLogger = addCategorizedLogger('frontAction', 'FRONT USER ACTION', 'bold');
 export const configureWorkerLogger = addCategorizedLogger('configureWorkerLogger', 'CONFIGURE WORKER', 'grey');
 export const runInWorkerLogger = addCategorizedLogger('runInWorker', 'RUN IN WORKER', 'grey');
 export const cleanLogger = addCategorizedLogger('clean', 'CLEAN', 'grey');

--- a/packages/user-management/spec/it/standard-user-workflow/core/account/StandardAccountAuthentication.spec.ts
+++ b/packages/user-management/spec/it/standard-user-workflow/core/account/StandardAccountAuthentication.spec.ts
@@ -1,5 +1,5 @@
 import 'jasmine';
-import { given, runInWorker, autoclean, frontUserAction } from '@zetapush/testing';
+import { given, runInWorker, autoclean, frontAction } from '@zetapush/testing';
 import { LegacyAdapterUserRepository } from '../../../../../src/standard-user-workflow/legacy';
 import { AccountCreationManager, StandardAccountStatus } from '../../../../../src';
 import { AccountCreationManagerInjectable } from '../../../../../src/';
@@ -63,9 +63,8 @@ describe(`StandardAccountAuthentication`, () => {
 
             const credentials = { login: 'odile.deray', password: 'password' };
 
-            await frontUserAction()
+            await frontAction(this)
               .name('Client connection')
-              .context(this)
               .loggedAs(credentials)
               .execute();
           },
@@ -98,9 +97,8 @@ describe(`StandardAccountAuthentication`, () => {
             const credentials = { login: 'odile.deray', password: 'wrong_password' };
 
             try {
-              await frontUserAction()
+              await frontAction(this)
                 .name('Client connection')
-                .context(this)
                 .loggedAs(credentials)
                 .execute();
               fail('authentication should have failed');
@@ -134,9 +132,8 @@ describe(`StandardAccountAuthentication`, () => {
             const credentials = { login: 'odile.deray', password: 'password' };
 
             try {
-              await frontUserAction()
+              await frontAction(this)
                 .name('Client connection')
-                .context(this)
                 .loggedAs(credentials)
                 .execute();
               fail('authentication should have failed');

--- a/packages/user-management/spec/it/standard-user-workflow/core/account/StandardAccountAuthentication.spec.ts
+++ b/packages/user-management/spec/it/standard-user-workflow/core/account/StandardAccountAuthentication.spec.ts
@@ -63,7 +63,11 @@ describe(`StandardAccountAuthentication`, () => {
 
             const credentials = { login: 'odile.deray', password: 'password' };
 
-            await frontUserAction('Client connection', this, async (api, client) => {}, credentials);
+            await frontUserAction()
+              .name('Client connection')
+              .context(this)
+              .loggedAs(credentials)
+              .execute();
           },
           5 * 60 * 1000
         );
@@ -94,7 +98,12 @@ describe(`StandardAccountAuthentication`, () => {
             const credentials = { login: 'odile.deray', password: 'wrong_password' };
 
             try {
-              await frontUserAction('Client connection', this, async (api, client) => {}, credentials);
+              await frontUserAction()
+                .name('Client connection')
+                .context(this)
+                .loggedAs(credentials)
+                .execute();
+              fail('authentication should have failed');
             } catch (e) {
               expect(e).toEqual('403::Handshake denied');
             }
@@ -125,7 +134,12 @@ describe(`StandardAccountAuthentication`, () => {
             const credentials = { login: 'odile.deray', password: 'password' };
 
             try {
-              await frontUserAction('Client connection', this, async (api, client) => {}, credentials);
+              await frontUserAction()
+                .name('Client connection')
+                .context(this)
+                .loggedAs(credentials)
+                .execute();
+              fail('authentication should have failed');
             } catch (e) {
               // TODO: Handle the proper error
               expect(e).toEqual('403::Handshake denied');


### PR DESCRIPTION
affects: @zetapush/integration, @zetapush/testing, @zetapush/user-management

BREAKING CHANGE:
frontUserAction test utility method signature has changed to be more understandable

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[x] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
With new namespace management from client, the frontUserAction test utility had to be updated.
frontUserAction started to be too complicated (too many parameters).


**What is the new behavior?**
frontUserAction now uses builder syntax to be more explicit and more understandable. The aim is to understand the test.


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
All tests that are using frontUserAction must be updated

**Other information**: