### PR TITLE
Feature/add grab all traffic cli option

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -66,6 +66,7 @@ program
   .option('-f, --front <front>', 'Push front on cloud platform', identity, DEFAULTS.FRONT_FOLDER_PATH)
   .option('-w, --worker <worker>', 'Push worker on cloud platform', identity, DEFAULTS.WORKER_FOLDER_PATH)
   .option('-s, --skip-provisioning', 'Skip provisioning steps', () => true, false)
+  .option('--grab-all-traffic', 'Grab all traffic (requests) to local worker', () => true, false)
   .option('--serve-front', 'Run local http server to serve your front code', () => true, false)
   .option('--skip-bootstrap', 'Discard all onApplicationBootstrap methods on run', () => true, false)
   .description('Run your code')

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -20,7 +20,8 @@ const {
   AccessDeniedIssueAnalyzer,
   InjectionIssueAnalyzer,
   CustomCloudServiceStartErrorAnalyzer,
-  OnApplicationBoostrapErrorAnalyser
+  OnApplicationBoostrapErrorAnalyser,
+  WorkerRegisterErrorAnalyser
 } = require('@zetapush/troubleshooting');
 
 const { helpMessageRun, helpMessagePush } = require('../src/utils/helper-messages');
@@ -40,6 +41,7 @@ ErrorAnalyzer.register(new InjectionIssueAnalyzer());
 ErrorAnalyzer.register(new MissingNpmDependencyErrorAnalyzer());
 ErrorAnalyzer.register(new CustomCloudServiceStartErrorAnalyzer());
 ErrorAnalyzer.register(new OnApplicationBoostrapErrorAnalyser());
+ErrorAnalyzer.register(new WorkerRegisterErrorAnalyser());
 
 function increaseVerbosity(v, total) {
   setVerbosity(total);

--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -29,6 +29,7 @@ const run = (command, config, declaration) => {
   const runner = new WorkerRunner(
     command.skipProvisioning,
     command.skipBootstrap,
+    command.grapAllTraffic,
     config,
     transports,
     new LocalDevEnvironmentProvider(config, 'dev', command.worker),

--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -29,7 +29,7 @@ const run = (command, config, declaration) => {
   const runner = new WorkerRunner(
     command.skipProvisioning,
     command.skipBootstrap,
-    command.grapAllTraffic,
+    command.grabAllTraffic,
     config,
     transports,
     new LocalDevEnvironmentProvider(config, 'dev', command.worker),

--- a/packages/platform-legacy/src/Queue/QueueTypes.ts
+++ b/packages/platform-legacy/src/Queue/QueueTypes.ts
@@ -222,6 +222,12 @@ export interface TaskConsumerConfiguration {
 export interface TaskConsumerRegistration {
   /**Task consumer maximum capacity at a given time. The server will not exceed that capacity when dispatching new tasks. Special tasks (provisioning) are not affected by this restriction.*/
   capacity?: number;
+  /**Routing information.*/
+  routing?: TaskConsumerRouting;
+}
+export interface TaskConsumerRouting {
+  /**The newly registered consumer demands that all traffic be routed to it.*/
+  exclusive?: boolean;
 }
 export interface TaskProgress {
   /**Optional context ID for logs. This value MUST have been previously given by the server to this connected client.*/

--- a/packages/testing/src/bdd/given.ts
+++ b/packages/testing/src/bdd/given.ts
@@ -20,9 +20,7 @@ import {
 } from '../utils/commands';
 import { TestContext, Dependencies } from '../utils/types';
 import { createApplication, DEFAULTS } from '@zetapush/common';
-import { Provider, InjectionToken, Module } from '@zetapush/core';
-import { WorkerRunner } from '@zetapush/worker/lib';
-import { Wrapper } from '../worker/test-instance';
+import { InjectionToken, Module } from '@zetapush/core';
 
 export const given = () => new Given();
 

--- a/packages/testing/src/bdd/when.ts
+++ b/packages/testing/src/bdd/when.ts
@@ -62,6 +62,7 @@ export const runInWorker = (testOrContext: Context, workerDeclaration: (...insta
       const runner = new WorkerRunner(
         false,
         false,
+        true, // Test must grab all traffic
         <ResolvedConfig>zetarc,
         transports,
         new LocalDevEnvironmentProvider(<ResolvedConfig>zetarc, 'test', projectDir || ''), // TODO: provide environment provider that suits to tests (one that can be constructed through given())

--- a/packages/troubleshooting/src/analyzer/worker-register-issue.ts
+++ b/packages/troubleshooting/src/analyzer/worker-register-issue.ts
@@ -1,0 +1,14 @@
+// ZetaPush modules
+import { info, trace } from '@zetapush/common';
+// Project modules
+import { ErrorAnalyzer, ErrorContextToAnalyze, ExitCode } from './error-analyzer';
+
+export class WorkerRegisterErrorAnalyser extends ErrorAnalyzer {
+  async getError(err: ErrorContextToAnalyze) {
+    if (err.code != 'WORKER_INSTANCE_REGISTER_FAILED') {
+      trace('not worker register issue');
+      return null;
+    }
+    return { code: ExitCode.WORKER_REGISTER_01 };
+  }
+}

--- a/packages/troubleshooting/src/index.ts
+++ b/packages/troubleshooting/src/index.ts
@@ -13,5 +13,6 @@ export { AccessDeniedIssueAnalyzer } from './analyzer/access-denied-issue';
 export { InjectionIssueAnalyzer } from './analyzer/injection-issue';
 export { CustomCloudServiceStartErrorAnalyzer } from './analyzer/custom-cloud-service-start-issue';
 export { OnApplicationBoostrapErrorAnalyser } from './analyzer/bootstrap-issue';
+export { WorkerRegisterErrorAnalyser } from './analyzer/worker-register-issue';
 
 export const errorHelper = ErrorHelper.getInstance(() => new CacheErrorHelper(new HttpDownloadErrorHelper(), false));

--- a/packages/troubleshooting/src/utils/constants.ts
+++ b/packages/troubleshooting/src/utils/constants.ts
@@ -25,7 +25,8 @@ export enum ExitCode {
   INJECTION_01 = 'INJECTION-01',
   SERVICE_04 = 'SERVICE-04',
   SERVICE_05 = 'SERVICE-05',
-  BOOTSTRAP_01 = 'BOOTSTRAP-01'
+  BOOTSTRAP_01 = 'BOOTSTRAP-01',
+  WORKER_REGISTER_01 = 'WORKER-REGISTER-01'
 }
 
 type ExitCodes = { [code in ExitCode]: number };
@@ -48,5 +49,6 @@ export const EXIT_CODES: ExitCodes = {
   'INJECTION-01': 71,
   'SERVICE-04': 94,
   'SERVICE-05': 95,
-  'BOOTSTRAP-01': 110
+  'BOOTSTRAP-01': 110,
+  'WORKER-REGISTER-01': 210
 };

--- a/packages/worker/src/client/run.ts
+++ b/packages/worker/src/client/run.ts
@@ -95,7 +95,7 @@ export class WorkerRunner extends EventEmitter {
   constructor(
     private skipProvisioning: boolean,
     private skipBootstrap: boolean,
-    private grapAllTraffic: boolean,
+    private grabAllTraffic: boolean,
     private config: ResolvedConfig,
     private transports: any[],
     private envProvider: EnvironmentProvider,
@@ -157,7 +157,7 @@ export class WorkerRunner extends EventEmitter {
         {
           ...clientConfig,
           transports: this.transports,
-          grapAllTraffic: this.grapAllTraffic
+          grabAllTraffic: this.grabAllTraffic
         },
         this.workerInstanceFactory
       );

--- a/packages/worker/src/client/run.ts
+++ b/packages/worker/src/client/run.ts
@@ -95,6 +95,7 @@ export class WorkerRunner extends EventEmitter {
   constructor(
     private skipProvisioning: boolean,
     private skipBootstrap: boolean,
+    private grapAllTraffic: boolean,
     private config: ResolvedConfig,
     private transports: any[],
     private envProvider: EnvironmentProvider,
@@ -155,7 +156,8 @@ export class WorkerRunner extends EventEmitter {
       const client = new WorkerClient(
         {
           ...clientConfig,
-          transports: this.transports
+          transports: this.transports,
+          grapAllTraffic: this.grapAllTraffic
         },
         this.workerInstanceFactory
       );

--- a/packages/worker/src/client/worker.ts
+++ b/packages/worker/src/client/worker.ts
@@ -21,7 +21,7 @@ export interface WorkerClientOptions {
   resource: string;
   timeout: number;
   capacity: number;
-  grapAllTraffic: boolean;
+  grabAllTraffic: boolean;
 }
 
 export class Worker extends Queue {
@@ -67,7 +67,7 @@ export class WorkerClient extends Client {
       resource = `node_js_worker_${uuid()}`,
       timeout = 60 * 1000,
       capacity = 100,
-      grapAllTraffic = false
+      grabAllTraffic = false
     }: WorkerClientOptions,
     workerInstanceFactory?: WorkerInstanceFactory
   ) {
@@ -111,7 +111,7 @@ export class WorkerClient extends Client {
       resource,
       timeout,
       capacity,
-      grapAllTraffic
+      grabAllTraffic
     };
   }
   /**
@@ -154,10 +154,11 @@ export class WorkerClient extends Client {
       },
       Type: Worker
     });
+    // TODO catch error if a worker is already registered with routing.exclusive mode
     queue.register({
       capacity: this.capacity,
       routing: {
-        exclusive: this.options.grapAllTraffic
+        exclusive: this.options.grabAllTraffic
       }
     });
     return instance;

--- a/packages/worker/src/client/worker.ts
+++ b/packages/worker/src/client/worker.ts
@@ -21,6 +21,7 @@ export interface WorkerClientOptions {
   resource: string;
   timeout: number;
   capacity: number;
+  grapAllTraffic: boolean;
 }
 
 export class Worker extends Queue {
@@ -48,6 +49,9 @@ export class WorkerClient extends Client {
    * A factory used to instantiate a WorkerInstance
    */
   private workerInstanceFactory?: WorkerInstanceFactory;
+  /**
+   * Options given to the worker client
+   */
   private options: WorkerClientOptions;
   /**
    * WorkerClient constructor
@@ -62,15 +66,11 @@ export class WorkerClient extends Client {
       developerPassword,
       resource = `node_js_worker_${uuid()}`,
       timeout = 60 * 1000,
-      capacity = 100
+      capacity = 100,
+      grapAllTraffic = false
     }: WorkerClientOptions,
     workerInstanceFactory?: WorkerInstanceFactory
   ) {
-    const authentication = () =>
-      Authentication.developer({
-        login: developerLogin,
-        password: developerPassword
-      });
     /**
      * Call Client constructor with specific parameters
      */
@@ -78,7 +78,11 @@ export class WorkerClient extends Client {
       platformUrl,
       appName,
       forceHttps,
-      authentication,
+      authentication: () =>
+        Authentication.developer({
+          login: developerLogin,
+          password: developerPassword
+        }),
       resource,
       transports
     });
@@ -106,7 +110,8 @@ export class WorkerClient extends Client {
       developerPassword,
       resource,
       timeout,
-      capacity
+      capacity,
+      grapAllTraffic
     };
   }
   /**
@@ -150,7 +155,10 @@ export class WorkerClient extends Client {
       Type: Worker
     });
     queue.register({
-      capacity: this.capacity
+      capacity: this.capacity,
+      routing: {
+        exclusive: this.options.grapAllTraffic
+      }
     });
     return instance;
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[x] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[x] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[x] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
Developer is unable to grap all traffic on worker registration

**What is the new behavior?**
Support --grab-all-traffic option to grap all traffic on worker registration


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: