### PR TITLE
feat(connection): Add reason of failed connection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
     "common [prepublish]": [
       "packages/common/src/**"
     ],
+    "client [prepublish]": [
+      "packages/client/src/**"
+    ],
     "core [prepublish]": [
       "packages/core/src/**"
     ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -117,6 +117,27 @@
       }
     },
     {
+      "label": "client [prepublish]",
+      "type": "npm",
+      "script": "prepublish",
+      "path": "packages/client/",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "isBackground": true,
+      "options": {
+
+      },
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true
+      }
+    },
+    {
       "label": "testing [prepublish]",
       "type": "npm",
       "script": "prepublish",

--- a/packages/client/src/client/basic.js
+++ b/packages/client/src/client/basic.js
@@ -1,5 +1,6 @@
 import { ClientHelper } from './helper.js';
 import { API_URL, FORCE_HTTPS } from '../utils/http.js';
+import { analyze } from '../utils/error-handler.js';
 import { ConnectionStatusListener } from '../connection/connection-status.js';
 
 /**
@@ -100,15 +101,11 @@ export class Client {
           // Resolve connection success
           resolve();
         };
-        const onError = (error) => {
+        const onError = (error, ext) => {
           // Remove connection status listener
           this.removeConnectionStatusListener(handler);
-          // Reject connection
-          reject({
-            code: 'CONNECTION_FAILED',
-            message: 'Unable to connect to platform',
-            cause: error
-          });
+          // Reject connection (analyze raw error before)
+          analyze(error, 'CONNECTION_FAILED', ext).then(reject);
         };
         // Register connection status listener
         handler = this.addConnectionStatusListener({

--- a/packages/client/src/client/helper.js
+++ b/packages/client/src/client/helper.js
@@ -200,7 +200,7 @@ export class ClientHelper {
         const { authentication = null } = ext;
         this.initialized(authentication);
       } else {
-        this.handshakeFailure(error);
+        this.handshakeFailure(error, ext);
       }
     });
 
@@ -217,9 +217,9 @@ export class ClientHelper {
           return;
         }
         if (Message.RECONNECT_NONE_VALUE === advice.reconnect) {
-          this.authenticationFailed(error);
+          this.authenticationFailed(error, ext);
         } else if (Message.RECONNECT_HANDSHAKE_VALUE === advice.reconnect) {
-          this.negotiationFailed(error);
+          this.negotiationFailed(error, ext);
         }
       }
     });
@@ -281,11 +281,11 @@ export class ClientHelper {
   /**
    * Notify listeners when handshake step succeed
    */
-  authenticationFailed(error) {
+  authenticationFailed(error, ext) {
     this.userId = null;
     this.userInfo = null;
     this.connectionListeners.filter(({ enabled }) => enabled).forEach(({ listener }) => {
-      listener.onFailedHandshake(error);
+      listener.onFailedHandshake(error, ext);
     });
   }
   /**
@@ -870,10 +870,10 @@ export class ClientHelper {
    * Negociate authentication
    * @param {error} error
    */
-  negotiationFailed(error) {
-    this.cometd._debug('ClientHelper::negotiationFailed', error);
+  negotiationFailed(error, ext) {
+    this.cometd._debug('ClientHelper::negotiationFailed', error, ext);
     this.connectionListeners.filter(({ enabled }) => enabled).forEach(({ listener }) => {
-      listener.onNegotiationFailed(error);
+      listener.onNegotiationFailed(error, ext);
     });
   }
   /**

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -6,6 +6,8 @@ export { SmartClient } from './client/smart.js';
 export { WeakClient } from './client/weak.js';
 
 export { uuid } from './utils/random.js';
+export * from './utils/error-handler.js';
+
 /**
  * SDK Version
  * @type {string}

--- a/packages/client/src/utils/error-handler.js
+++ b/packages/client/src/utils/error-handler.js
@@ -1,0 +1,152 @@
+export class BaseError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.cause = cause;
+    this.name = this.constructor.name;
+  }
+
+  toString() {
+    return `${this.getType(this)}${this.message}${this.getCauseString()}`;
+  }
+
+  getType(error) {
+    return `[${error.name || 'raw error'}] `;
+  }
+
+  getCauseString() {
+    if (!this.cause) {
+      return '';
+    }
+    return `\nCause: ${
+      this.cause instanceof BaseError ? this.cause.toString() : this.getTypedCauseMessage(this.cause)
+    }`;
+  }
+
+  getTypedCauseMessage(error) {
+    return `${this.getType(error)}${error.message || error}`;
+  }
+}
+
+/**
+ * Analyze a technical error to provide a more understandable error for end-users and developers.
+ *
+ * @param {any} error The error to analyze
+ * @param {any} context Any additional information about the execution context that may be useful for error analysis
+ * @param {Object} ext Any object provided by the server
+ * @returns {Promise} a promise that returns a formatted error
+ */
+export const analyze = (error, context, ext) => {
+  return defaultAnalyzer().analyze(error, context, ext);
+};
+
+const defaultAnalyzer = () =>
+  new ErrorAnalyzer(new AccountStatusAnalyzer(), new AuthenticationErrorAnalyzer(), new ConnectionErrorAnalyzer());
+
+class ErrorAnalyzer {
+  constructor(...delegates) {
+    this.delegates = delegates;
+  }
+
+  async analyze(error, context, ext) {
+    for (let delegate of this.delegates) {
+      const analyzed = await delegate.analyze(error, context, ext);
+      if (analyzed) {
+        return analyzed;
+      }
+    }
+    return error;
+  }
+}
+
+class AccountStatusAnalyzer {
+  async analyze(error, context, ext) {
+    // if not an error due to account inactive => skip
+    if (context !== 'CONNECTION_FAILED' || !this.isAccountInactive(error, ext)) {
+      return null;
+    }
+    if (this.isAccountNotConfirmed(ext)) {
+      return new AccountNotConfirmedError(`Your account has been created but you haven't confirmed it yet`, error, ext);
+    } else {
+      return new AccountDisabledError(`Your account has been disabled`, error, ext);
+    }
+  }
+
+  isAccountInactive(error, ext) {
+    if (!ext || !ext.error) {
+      return false;
+    }
+    return error === '403::Handshake denied' && ext.error.code === 'ACCOUNT_INACTIVE';
+  }
+
+  isAccountNotConfirmed(ext) {
+    // TODO: works only with standard status. How to provide custom status ?
+    const { cause } = ext.error;
+    const { context } = cause || {};
+    const { status } = context || {};
+    return status && status.data === 'WAITING_FOR_CONFIRMATION';
+  }
+}
+
+class AuthenticationErrorAnalyzer {
+  async analyze(error, context, ext) {
+    // if not an error due to authentication failure => skip
+    if (context !== 'CONNECTION_FAILED' || !this.isAuthenticationFailed(error)) {
+      return null;
+    }
+    if (this.isBadCredentials(ext)) {
+      return new BadCredentialsError(`The login and/or password are incorrect`, error, ext);
+    }
+    if (this.isAuthenticationTokenNotFound(ext)) {
+      return new AuthenticationTokenNotFoundError(`The authentication token doesn't exist`, error, ext);
+    }
+    return null;
+  }
+
+  isAuthenticationFailed(error) {
+    return error === '403::Handshake denied';
+  }
+  isBadCredentials(ext) {
+    return ext.error.code === 'SIMPLE_UNMATCHED_LOGIN_PASSWORD';
+  }
+  isAuthenticationTokenNotFound(ext) {
+    return ext.error.code === 'TOKEN_NOT_FOUND';
+  }
+}
+
+class ConnectionErrorAnalyzer {
+  async analyze(error, context, ext) {
+    // if not an error due to connection error => skip
+    if (context !== 'CONNECTION_FAILED') {
+      return null;
+    }
+    if (this.isNetworkError(error)) {
+      // TODO: add more useful information
+      return new ConnectionEstablishmentFailed(`Unable to establish connection to the platform`, error);
+    }
+    return new ConnectionError(`Failed to connect to the platform`, new PlatformError(error));
+  }
+
+  isNetworkError(error) {
+    return error.message === 'Negotiation Failed' || error.message === 'No Server Url Available';
+  }
+}
+
+export class PlatformError extends BaseError {
+  constructor(rawError) {
+    this.message = rawError.message;
+    this.code = rawError.code;
+    this.cause = new PlatformError(rawError.cause);
+  }
+}
+
+export class ConnectionError extends BaseError {
+  constructor(message, cause, ext) {
+    super(message, cause);
+    this.ext = ext;
+  }
+}
+export class AccountNotConfirmedError extends ConnectionError {}
+export class AccountDisabledError extends ConnectionError {}
+export class BadCredentialsError extends ConnectionError {}
+export class AuthenticationTokenNotFoundError extends BadCredentialsError {}
+export class ConnectionEstablishmentFailed extends ConnectionError {}

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@zetapush/testing": "0.33.1",
+    "@zetapush/client": "0.33.1",
     "jasmine": "3.1.0",
     "jasmine-reporters": "2.3.1"
   }

--- a/packages/integration/spec/user-management/default-standard-user-workflow.spec.js
+++ b/packages/integration/spec/user-management/default-standard-user-workflow.spec.js
@@ -1,4 +1,5 @@
 const { given, autoclean, frontAction } = require('@zetapush/testing');
+const { AccountNotConfirmedError, BadCredentialsError } = require('@zetapush/client');
 
 describe(`As developer with
   - valid account
@@ -90,7 +91,7 @@ describe(`As developer with
   });
 
   describe(`Nominal case with no activated account`, () => {
-    it(
+    fit(
       `The user can't connect with handshake failed`,
       async () => {
         let resultOfSignUp = null;
@@ -150,7 +151,9 @@ describe(`As developer with
             .loggedAs('login', 'password')
             .execute();
         } catch (e) {
-          expect(e).toEqual('403::Handshake denied');
+          expect(() => {
+            throw e;
+          }).toThrowError(AccountNotConfirmedError);
         }
       },
       60 * 1000 * 10
@@ -230,7 +233,9 @@ describe(`As developer with
             /**/ .and()
             .execute();
         } catch (e) {
-          expect(e).toEqual('403::Handshake denied');
+          expect(() => {
+            throw e;
+          }).toThrowError(BadCredentialsError);
         }
       },
       60 * 1000 * 10

--- a/packages/user-management/spec/it/standard-user-workflow/core/account/StandardAccountAuthentication.spec.ts
+++ b/packages/user-management/spec/it/standard-user-workflow/core/account/StandardAccountAuthentication.spec.ts
@@ -5,6 +5,7 @@ import { AccountCreationManager, StandardAccountStatus } from '../../../../../sr
 import { AccountCreationManagerInjectable } from '../../../../../src/';
 import { AccountCreationManagerConfigurerImpl } from '../../../../../src/standard-user-workflow/configurer/account';
 import { TimestampBasedUuidGenerator } from '../../../../../src/common/core';
+import { AccountNotConfirmedError, BadCredentialsError } from '@zetapush/client/lib';
 
 describe(`StandardAccountAuthentication`, () => {
   const registrationConfigurer = jasmine.createSpyObj('registrationConfigurer', ['account', 'welcome', 'confirmation']);
@@ -103,7 +104,9 @@ describe(`StandardAccountAuthentication`, () => {
                 .execute();
               fail('authentication should have failed');
             } catch (e) {
-              expect(e).toEqual('403::Handshake denied');
+              expect(() => {
+                throw e;
+              }).toThrowError(BadCredentialsError);
             }
           },
           5 * 60 * 1000
@@ -138,8 +141,9 @@ describe(`StandardAccountAuthentication`, () => {
                 .execute();
               fail('authentication should have failed');
             } catch (e) {
-              // TODO: Handle the proper error
-              expect(e).toEqual('403::Handshake denied');
+              expect(() => {
+                throw e;
+              }).toThrowError(AccountNotConfirmedError);
             }
           },
           5 * 60 * 1000


### PR DESCRIPTION
Client is now able to indicate why connection has failed (BadCredentialsError,
AccountNotConfirmedError, ConnectionError...)

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[x] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
When client can't connect, there is no information about the reason why connection has failed.


**What is the new behavior?**
The client analyzes the error and returns a well formatted exception (a class that can be used with instanceof and also checked using name property).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: