### PR TITLE
fix(api): Do not transform API return values

### DIFF
--- a/packages/client/src/client/helper.js
+++ b/packages/client/src/client/helper.js
@@ -438,7 +438,7 @@ export class ClientHelper {
           const subscriptions = {};
           return new Promise((resolve, reject) => {
             const handler = ({ data = {} }) => {
-              const { result = {}, errors = [], requestId } = data;
+              const { result, errors = [], requestId } = data;
               if (requestId === uniqRequestId) {
                 // Handle errors
                 if (errors.length > 0) {
@@ -496,7 +496,7 @@ export class ClientHelper {
               }
             };
             const onSuccess = ({ data = {} }) => {
-              const { result = {}, requestId } = data;
+              const { result, requestId } = data;
               if (requestId === uniqRequestId) {
                 resolve(result);
                 this.unsubscribe(subscriptions);
@@ -620,7 +620,7 @@ export class ClientHelper {
       const subscriptions = {};
       return new Promise((resolve, reject) => {
         const handler = ({ data = {} }) => {
-          const { result = {}, errors = [], requestId } = data;
+          const { result, errors = [], requestId } = data;
           if (requestId === uniqRequestId) {
             // Handle errors
             if (errors.length > 0) {
@@ -709,7 +709,7 @@ export class ClientHelper {
           }
         };
         const onSuccess = ({ data = {} }) => {
-          const { result = {}, requestId } = data;
+          const { result, requestId } = data;
           if (requestId === uniqRequestId) {
             resolve(result);
             this.unsubscribe(subscriptions);

--- a/packages/integration/spec/return-values.spec.js
+++ b/packages/integration/spec/return-values.spec.js
@@ -1,0 +1,73 @@
+const { given, frontAction, autoclean } = require('@zetapush/testing');
+
+describe(`Front calling API methods`, () => {
+  afterEach(async () => {
+    await autoclean(this);
+  });
+
+  beforeEach(async () => {
+    await given()
+      /**/ .credentials()
+      /*   */ .fromEnv()
+      /*   */ .and()
+      /**/ .project()
+      /*   */ .template()
+      /*     */ .sourceDir('return-values')
+      /*     */ .and()
+      /*   */ .and()
+      /**/ .worker()
+      /*   */ .up()
+      /*   */ .and()
+      /**/ .apply(this);
+  });
+
+  it(
+    `receives values returned by worker API`,
+    async () => {
+      await frontAction(this)
+        .name('call API method that returns undefined')
+        .execute(async (api) => {
+          expect(await api.returnsUndefined()).toBeUndefined();
+        });
+
+      await frontAction(this)
+        .name('call API method that returns null')
+        .execute(async (api) => {
+          // FIXME: need platform update to correctly serialize null values
+          // expect(await api.returnsNull()).toBeNull();
+          expect(await api.returnsNull()).toBeFalsy();
+        });
+
+      await frontAction(this)
+        .name('call API method that returns nothing')
+        .execute(async (api) => {
+          expect(await api.returnsNothing()).toBeUndefined();
+        });
+
+      await frontAction(this)
+        .name('call API method that returns empty object')
+        .execute(async (api) => {
+          expect(await api.returnsEmptyObject()).toEqual({});
+        });
+
+      await frontAction(this)
+        .name('call API method that returns empty array')
+        .execute(async (api) => {
+          expect(await api.returnsEmptyArray()).toEqual([]);
+        });
+
+      await frontAction(this)
+        .name('call API method that returns empty string')
+        .execute(async (api) => {
+          expect(await api.returnsEmptyString()).toEqual('');
+        });
+
+      await frontAction(this)
+        .name('call API method that returns 0')
+        .execute(async (api) => {
+          expect(await api.returnsZero()).toEqual(0);
+        });
+    },
+    60 * 1000 * 10
+  );
+});

--- a/packages/integration/spec/templates/return-values/package.json
+++ b/packages/integration/spec/templates/return-values/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "return-values",
+  "version": "0.1.0",
+  "main": "worker/index.ts",
+  "private": true,
+  "scripts": {
+    "deploy": "zeta push",
+    "start": "zeta run",
+    "troubleshoot": "zeta troubleshoot"
+  },
+  "dependencies": {
+    "@zetapush/cli":  "0.32.0",
+    "@zetapush/core":  "0.32.0"
+  }
+}

--- a/packages/integration/spec/templates/return-values/tsconfig.json
+++ b/packages/integration/spec/templates/return-values/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/packages/integration/spec/templates/return-values/worker/index.ts
+++ b/packages/integration/spec/templates/return-values/worker/index.ts
@@ -1,0 +1,27 @@
+export default class Api {
+  async returnsUndefined() {
+    return undefined;
+  }
+
+  async returnsNothing() {}
+
+  async returnsNull() {
+    return null;
+  }
+
+  async returnsEmptyObject() {
+    return {};
+  }
+
+  async returnsEmptyArray() {
+    return [];
+  }
+
+  async returnsZero() {
+    return 0;
+  }
+
+  async returnsEmptyString() {
+    return '';
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: A client that calls an API method returning null or undefined value will no longer
receive an empty object

182

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[x] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
See #182 


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
A client that calls an API method returning null or undefined value will no longer
receive an empty object

**Other information**: