### PR TITLE
feat(replace-progression-implementation): replace node-progress-bars by log-update

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "execa": "0.10.0",
     "find-free-port": "2.0.0",
     "hot-module-replacement": "3.0.1",
-    "node-progress-bars": "1.0.8",
+    "log-update": "2.3.0",
     "ora": "2.1.0",
     "prompts": "1.1.0",
     "reflect-metadata": "0.1.12",

--- a/packages/cli/src/commands/push.js
+++ b/packages/cli/src/commands/push.js
@@ -2,7 +2,7 @@ const path = require('path');
 const os = require('os');
 const fs = require('fs');
 
-const { upload, filter, BLACKLIST, log, error, mkdir, trace } = require('@zetapush/common');
+const { upload, filter, BLACKLIST, log, error, mkdir, trace, info } = require('@zetapush/common');
 const { Queue } = require('@zetapush/platform-legacy');
 const { displayHelp } = require('@zetapush/troubleshooting');
 
@@ -45,6 +45,7 @@ const archive = (command, config, declaration) => {
  */
 const push = (command, config, declaration) => {
   log(`Execute command <push> ${command.worker}`);
+  info(`Bundle your application components`);
   archive(command, config, declaration)
     .then((rootArchive) => upload(fs.createReadStream(rootArchive), config))
     .then((recipe) => {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@types/node": "10.5.7",
-    "@zetapush/core": "0.33.4",
-    "@zetapush/cli": "0.33.4",
-    "@zetapush/platform-legacy": "0.33.4",
+    "@zetapush/core": "0.34.0",
+    "@zetapush/cli": "0.34.0",
+    "@zetapush/platform-legacy": "0.34.0",
     "typescript": "3.0.1"
   }
 }

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@zetapush/integration",
-  "version": "0.33.1",
   "private": true,
   "scripts": {
     "test": "jasmine",
@@ -12,8 +11,8 @@
     "toxy": "^0.3.15"
   },
   "devDependencies": {
-    "@zetapush/testing": "0.33.1",
-    "@zetapush/client": "0.33.1",
+    "@zetapush/testing": "0.34.0",
+    "@zetapush/client": "0.34.0",
     "jasmine": "3.1.0",
     "jasmine-reporters": "2.3.1"
   }


### PR DESCRIPTION
affects: @zetapush/cli, @zetapush/example, @zetapush/integration

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[x] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
Current progression (progress bars) need native module (get-cursor-position)

**What is the new behavior?**
New version log-update doesn't need native module

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: