### PR TITLE
feat(security): no longer display developer password in zetarc file

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,9 +1,17 @@
 {
-	"name": "@zetapush/cli",
-	"version": "0.33.4",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
+		"aes-js": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.1.tgz",
+			"integrity": "sha512-cEA0gBelItZZV7iBiL8ApCiNgc+gBWJJ4uoORhbu6vOqAJ0UL9wIlxr4RI7ij9SSVzy6AnPwiu37kVYiHCl3nw=="
+		},
+		"ansi-escapes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -15,21 +23,6 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
 				"color-convert": "^1.9.0"
-			}
-		},
-		"ansi.js": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/ansi.js/-/ansi.js-0.0.5.tgz",
-			"integrity": "sha1-4+nkXraXe6Du7u0RZ30SFEZ1NIw=",
-			"requires": {
-				"on-new-line": "0.0.1"
-			},
-			"dependencies": {
-				"on-new-line": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/on-new-line/-/on-new-line-0.0.1.tgz",
-					"integrity": "sha1-mTOcsG3P4+eNaWSi7yrzdKFF+Ps="
-				}
 			}
 		},
 		"argparse": {
@@ -170,11 +163,6 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
-		"end-with": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/end-with/-/end-with-1.0.2.tgz",
-			"integrity": "sha1-pDJ1WrT1Hn/HTzpxnGuB311mi9w="
-		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -220,11 +208,6 @@
 			"resolved": "https://registry.npmjs.org/find-free-port/-/find-free-port-2.0.0.tgz",
 			"integrity": "sha1-SyLl9leesaOMQaxryz7+0bbamxs="
 		},
-		"get-cursor-position": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/get-cursor-position/-/get-cursor-position-1.0.5.tgz",
-			"integrity": "sha1-FVjDWqBWcm6ucE1VkK6qWUWYn1o="
-		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -266,7 +249,7 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
 				"builtin-modules": "^1.0.0"
@@ -276,6 +259,11 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -340,6 +328,16 @@
 				"chalk": "^2.0.1"
 			}
 		},
+		"log-update": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+			"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"cli-cursor": "^2.0.0",
+				"wrap-ansi": "^3.0.1"
+			}
+		},
 		"make-error": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -396,18 +394,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
-		"node-progress-bars": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/node-progress-bars/-/node-progress-bars-1.0.8.tgz",
-			"integrity": "sha1-3cv7ZmV/Kk/U6PL84AvDJLXLlTU=",
-			"requires": {
-				"ansi.js": "0.0.5",
-				"end-with": "^1.0.2",
-				"get-cursor-position": "^1.0.4",
-				"on-new-line": "1.0.0",
-				"start-with": "^1.0.2"
-			}
-		},
 		"node-watch": {
 			"version": "0.5.8",
 			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.5.8.tgz",
@@ -420,11 +406,6 @@
 			"requires": {
 				"path-key": "^2.0.0"
 			}
-		},
-		"on-new-line": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/on-new-line/-/on-new-line-1.0.0.tgz",
-			"integrity": "sha1-hYW8KGbIwOGS5BCm1jvdFyIUiuc="
 		},
 		"onetime": {
 			"version": "2.0.1",
@@ -584,10 +565,14 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
-		"start-with": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/start-with/-/start-with-1.0.2.tgz",
-			"integrity": "sha1-oGml9GqV/Kfwh0+Foo9lPQCVwmc="
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			}
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
@@ -652,6 +637,15 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
 				"isexe": "^2.0.0"
+			}
+		},
+		"wrap-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+			"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"yn": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "@zetapush/platform-legacy": "0.34.2",
     "@zetapush/troubleshooting": "0.34.2",
     "@zetapush/worker": "0.34.2",
+    "aes-js": "3.1.1",
     "chalk": "2.4.1",
     "commander": "2.16.0",
     "cosmiconfig": "5.0.5",

--- a/packages/cli/src/utils/crypto.js
+++ b/packages/cli/src/utils/crypto.js
@@ -1,0 +1,43 @@
+const aesjs = require('aes-js');
+
+class Base64 {
+  static decode(encoded) {
+    return Buffer.from(encoded, 'base64').toString();
+  }
+  static encode(decoded) {
+    return Buffer.from(decoded).toString('base64');
+  }
+}
+
+class Crypto {
+  static get salt() {
+    return 'JavaScriptRocks';
+  }
+  constructor(key) {
+    const KEY_SIZE = 32;
+    const DEFAULT_KEY = '1357986420AETUOLJFSWWCBNXVZRYIQD';
+    key = key.padStart(KEY_SIZE, DEFAULT_KEY).substring(0, KEY_SIZE);
+    key = [...key].map((char) => char.codePointAt(0));
+    this.controller = () => new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(5));
+  }
+  encrypt(text) {
+    // Convert text to bytes
+    const bytes = aesjs.utils.utf8.toBytes(Crypto.salt + text);
+    // The counter is optional, and if omitted will begin at 1
+    const encrypted = this.controller().encrypt(bytes);
+    // To print or store the binary data, you may convert it to hex
+    return Base64.encode(aesjs.utils.hex.fromBytes(encrypted));
+  }
+  decrypt(encrypted) {
+    // When ready to decrypt the hex string, convert it back to bytes
+    const bytes = aesjs.utils.hex.toBytes(Base64.decode(encrypted));
+    // The counter mode of operation maintains internal state, so to
+    // decrypt a new instance must be instantiated.
+    const decrypted = this.controller().decrypt(bytes);
+    // Convert our bytes back into text
+    const text = aesjs.utils.utf8.fromBytes(decrypted);
+    return text.substring(Crypto.salt.length);
+  }
+}
+
+module.exports = { Crypto };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[x] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
Current format serialize developer password in zetarc file

**What is the new behavior?**
Developer password is no longer stored in zetarc without encoding

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: