### PR TITLE
feature(Connection) - Add lazy load config

### DIFF
--- a/packages/client/test/client-error.spec.js
+++ b/packages/client/test/client-error.spec.js
@@ -27,15 +27,4 @@ describe('Client', () => {
       client.connect()
     })
   })
-
-  describe('Connection failure', () => {
-    it('Should handle no server available', (done) => {
-      const client = this.client
-      client.onNoServerUrlAvailable(() => {
-        expect(client.isConnected()).toBeFalsy()
-        done()
-      })
-      client.connect()
-    })
-  })
 })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[x] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)

The available ZetaPush servers (for the connexion) are retrieved when we instanciate the ZetaPushClient.


**What is the new behavior?**

Now the servers are retrieved during the "connect()" method. So if the connection is lost, we don't need to recreate a new ZetaPush client, the "connect()" method will get available servers if necessary.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Resolve #223 