### PR TITLE
fix(Errors) - Error handling need to endure obfuscation

### DIFF
--- a/packages/client/src/utils/error-handler.js
+++ b/packages/client/src/utils/error-handler.js
@@ -1,8 +1,8 @@
 export class BaseError extends Error {
-  constructor(message, cause) {
+  constructor(name, message, cause) {
     super(message);
     this.cause = cause;
-    this.name = this.constructor.name;
+    this.name = name;
   }
 
   toString() {
@@ -65,9 +65,14 @@ class AccountStatusAnalyzer {
       return null;
     }
     if (this.isAccountNotConfirmed(ext)) {
-      return new AccountNotConfirmedError(`Your account has been created but you haven't confirmed it yet`, error, ext);
+      return new AccountNotConfirmedError(
+        `AccountNotConfirmedError`,
+        `Your account has been created but you haven't confirmed it yet`,
+        error,
+        ext
+      );
     } else {
-      return new AccountDisabledError(`Your account has been disabled`, error, ext);
+      return new AccountDisabledError(`AccountDisabledError`, `Your account has been disabled`, error, ext);
     }
   }
 
@@ -94,10 +99,15 @@ class AuthenticationErrorAnalyzer {
       return null;
     }
     if (this.isBadCredentials(ext)) {
-      return new BadCredentialsError(`The login and/or password are incorrect`, error, ext);
+      return new BadCredentialsError(`BadCredentialsError`, `The login and/or password are incorrect`, error, ext);
     }
     if (this.isAuthenticationTokenNotFound(ext)) {
-      return new AuthenticationTokenNotFoundError(`The authentication token doesn't exist`, error, ext);
+      return new AuthenticationTokenNotFoundError(
+        `AuthenticationTokenNotFoundError`,
+        `The authentication token doesn't exist`,
+        error,
+        ext
+      );
     }
     return null;
   }
@@ -121,9 +131,17 @@ class ConnectionErrorAnalyzer {
     }
     if (this.isNetworkError(error)) {
       // TODO: add more useful information
-      return new ConnectionEstablishmentFailed(`Unable to establish connection to the platform`, error);
+      return new ConnectionEstablishmentFailed(
+        `ConnectionEstablishmentFailed`,
+        `Unable to establish connection to the platform`,
+        error
+      );
     }
-    return new ConnectionError(`Failed to connect to the platform`, new PlatformError(error));
+    return new ConnectionError(
+      `ConnectionError`,
+      `Failed to connect to the platform`,
+      new PlatformError(`PlatformError`, error)
+    );
   }
 
   isNetworkError(error) {
@@ -132,17 +150,17 @@ class ConnectionErrorAnalyzer {
 }
 
 export class PlatformError extends BaseError {
-  constructor(rawError) {
+  constructor(name, rawError) {
     const cause = rawError.cause ? new PlatformError(rawError.cause) : null;
-    super(rawError, cause);
+    super(name, rawError, cause);
     this.message = rawError.message;
     this.code = rawError.code;
   }
 }
 
 export class ConnectionError extends BaseError {
-  constructor(message, cause, ext) {
-    super(message, cause);
+  constructor(name, message, cause, ext) {
+    super(name, message, cause);
     this.ext = ext;
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[x] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)

When the code is minified, the name of errors are not visible because the class was renamed (ofuscation).


**What is the new behavior?**

We don't base our error names on the classes name


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: