### PR TITLE
fix(log): purge process output stream before spinner stop

### DIFF
--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -58,6 +58,8 @@ const run = async (command, config, declaration) => {
     spinner.start();
   });
   runner.on(WorkerRunnerEvents.STARTED, () => {
+    // Purge process output stream
+    console.log(String());
     spinner.stop();
     info('Worker is up!');
   });
@@ -66,6 +68,8 @@ const run = async (command, config, declaration) => {
     spinner.start();
   });
   runner.on(WorkerRunnerEvents.RELOADED, () => {
+    // Purge process output stream
+    console.log(String());
     spinner.stop();
     info('Worker is up!');
   });


### PR DESCRIPTION
affects: @zetapush/cli

ISSUES CLOSED: #151

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[x] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
Purge process output stream on spinner stop

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: