### PR TITLE
fix(client): remove queued subscriptions listeners on connection broken

### DIFF
--- a/packages/client/src/client/helper.js
+++ b/packages/client/src/client/helper.js
@@ -326,6 +326,15 @@ export class ClientHelper {
    * Notify listeners when connection is broken
    */
   connectionBroken() {
+    // Clean queue subscriptions
+    this.subscribeQueue.forEach((queued) => {
+      for (let method in queued.subscriptions) {
+        if (queued.subscriptions.hasOwnProperty(method)) {
+          queued.subscriptions[method] = void 0;
+        }
+      }
+    });
+    // Notify listeners
     this.connectionListeners.filter(({ enabled }) => enabled).forEach(({ listener }) => {
       listener.onConnectionBroken();
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[x] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
When connection is broken local subscriptions are not cleaned

**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: