### PR TITLE
fix(testing): testing tools were not adapted for our clients

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -73,6 +73,7 @@ program
   .option('--grab-all-traffic', 'Grab all traffic (requests) to local worker', () => true, false)
   .option('--serve-front', 'Run local http server to serve your front code', () => true, false)
   .option('--skip-bootstrap', 'Discard all onApplicationBootstrap methods on run', () => true, false)
+  .option('--ipc <id>', 'Connect to an IPC server to send messages')
   .description('Run your code')
   .action((command) =>
     createApp(command)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,8 @@
     "serve-handler": "5.0.7",
     "ts-node": "7.0.0",
     "typescript": "3.1.6",
-    "zip-dir": "1.0.2"
+    "zip-dir": "1.0.2",
+    "node-ipc": "9.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,9 @@
     "serve-handler": "5.0.7",
     "ts-node": "7.0.0",
     "typescript": "3.1.6",
-    "zip-dir": "1.0.2",
+    "zip-dir": "1.0.2"
+  },
+  "peerDependencies": {
     "node-ipc": "9.1.1"
   },
   "publishConfig": {

--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -1,6 +1,5 @@
 const process = require('process');
 const ora = require('ora');
-const ipc = require('node-ipc');
 
 const {
   log,
@@ -42,7 +41,9 @@ const run = async (command, config, declaration) => {
     getCometdLogLevel()
   );
 
-  registerIpc(runner, command.ipc);
+  if (command.ipc) {
+    registerIpc(runner, command.ipc);
+  }
 
   const spinner = ora('Starting worker... \n');
 
@@ -158,6 +159,14 @@ const findAndRegisterLocalPorts = async (command) => {
 };
 
 const registerIpc = (runner, name) => {
+  let ipc;
+  try {
+    ipc = require('node-ipc');
+  } catch (e) {
+    error(`node-ipc not installed so testing module can't communicate with tested application`);
+    displayHelp(e);
+  }
+
   ipc.config.id = 'zetapush-worker';
   ipc.config.retry = 1500;
   ipc.config.logger = trace;

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -37,7 +37,10 @@
     "find-free-port": "2.0.0",
     "rimraf": "2.6.2",
     "tree-kill": "1.2.1",
-    "winston": "3.1.0"
+    "winston": "3.1.0",
+    "find-in-files": "0.5.0",
+    "find-up": "3.0.0",
+    "node-ipc": "9.1.1"
   },
   "devDependencies": {
     "@types/execa": "0.9.0",

--- a/packages/testing/src/bdd/clean.ts
+++ b/packages/testing/src/bdd/clean.ts
@@ -32,14 +32,14 @@ export const autoclean = async (testOrContext: Context, disableResetNpmRegistry 
       cleanLogger.warn('Failed to autoclean (destroy worker). Skipping the error.', e);
     }
   }
-  if (context && context.projectDir) {
+  if (context && context.projectDir && context.clean.nukeProject) {
     try {
       cleanLogger.warn('nuking project...', context.projectDir);
       await nukeProject(context.projectDir);
     } catch (e) {
       cleanLogger.warn('Failed to autoclean (nukeProject). Skipping the error.', e);
     }
-  } else if (context && context.zetarc) {
+  } else if (context && context.zetarc && context.clean.nukeApp) {
     try {
       cleanLogger.warn('nuking app...', context.zetarc);
       await nukeApp(<ResolvedConfig>context.zetarc);

--- a/packages/testing/src/utils/types.ts
+++ b/packages/testing/src/utils/types.ts
@@ -5,7 +5,11 @@ import { WorkerRunner } from '@zetapush/worker';
 
 // export type ConfigurationFunction = (...dependencies: any[]) => Promise<Provider[] | null>;
 export type Dependencies = Array<Function | InjectionToken<any>> | (() => Array<Function | InjectionToken<any>>);
+
+export const initialized = Symbol('initialized');
+
 export interface TestContext {
+  [initialized]: boolean;
   zetarc: Config;
   projectDir?: string;
   processLocalRegistry?: string;
@@ -18,6 +22,10 @@ export interface TestContext {
     cometd: 'info' | 'debug' | 'warn';
     winston: 'silly' | 'verbose' | 'debug' | 'info' | 'warn' | 'error';
     cli: number;
+  };
+  clean: {
+    nukeProject: boolean;
+    nukeApp: boolean;
   };
   // configurationFunction?: ConfigurationFunction;
 }


### PR DESCRIPTION
affects: @zetapush/cli, @zetapush/testing

As free trial accounts only have one shared application with one environment, we need to provide
tools that correspond to this usage:
- If a worker has already been created in development, now we
really wait for its starting (we don't rely only on ZetaPush cloud, we also check through IPC if the
worker is really ready)
- We only clean application and project if it has been automatically created
by the test. As there is only one application, we can't delete it
- Add a message to indicate if
await has been forgotten

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[x] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[x] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
As free trial accounts only have one shared application with one environment, we need to provide
tools that correspond to this usage


**What is the new behavior?**
- If a worker has already been created in development, now we
really wait for its starting (we don't rely only on ZetaPush cloud, we also check through IPC if the
worker is really ready)
- We only clean application and project if it has been automatically created
by the test. As there is only one application, we can't delete it
- Add a message to indicate if
await has been forgotten


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: