### PR TITLE
feat(context): allow to configure relative URL to benefit from auto conf

### DIFF
--- a/packages/cli/src/loader/config.js
+++ b/packages/cli/src/loader/config.js
@@ -23,7 +23,7 @@ const checkZetarcValidJson = (command) => {
   let content;
   try {
     content = fs.readFileSync(path.resolve(command.worker, '.zetarc'), 'utf8');
-  } catch {}
+  } catch (e) {}
   if (content) {
     try {
       JSON.parse(content);

--- a/packages/user-management/src/common/configurer/grammar.ts
+++ b/packages/user-management/src/common/configurer/grammar.ts
@@ -224,8 +224,10 @@ export interface SmsConfigurer<P> extends And<P> {
 }
 
 export interface SuccessFailureRedirectionConfigurer<P> extends And<P> {
+  // TODO: allow functions and context
   successUrl(url: string): SuccessFailureRedirectionConfigurer<P>;
 
+  // TODO: allow functions and context
   failureUrl(url: string): SuccessFailureRedirectionConfigurer<P>;
 }
 

--- a/packages/user-management/src/standard-user-workflow/configurer/confirmation/RegistrationConfirmationConfigurer.ts
+++ b/packages/user-management/src/standard-user-workflow/configurer/confirmation/RegistrationConfirmationConfigurer.ts
@@ -104,7 +104,7 @@ export class RegistrationConfirmationConfigurerImpl extends AbstractParent<Regis
     providerRegistry.required(
       scopedDependency('confirmation-email.sender', MessageSenderInjectable),
       new MissingMandatoryConfigurationError(
-        `Confirmation is enabled but neither email nor sms is enabled to send confirmation message`
+        `Confirmation is enabled but neither email nor sms is enabled/configured to send confirmation message`
       )
     );
 

--- a/packages/user-management/src/standard-user-workflow/configurer/confirmation/SuccessFailureRedirectionConfigurer.ts
+++ b/packages/user-management/src/standard-user-workflow/configurer/confirmation/SuccessFailureRedirectionConfigurer.ts
@@ -8,6 +8,7 @@ import { Provider } from '@zetapush/core';
 import { RedirectionProviderInjectable } from '../../api';
 import { StaticUrlRedirectionProvider } from '../../core/account/confirmation/StaticUrlRedirectionProvider';
 import { ConfigurationProperties, ZetaPushContext } from '@zetapush/core';
+import { trace } from '@zetapush/common';
 
 export class SuccessFailureRedirectionConfigurerImpl<P> extends AbstractParent<P>
   implements SuccessFailureRedirectionConfigurer<P>, Configurer {
@@ -29,7 +30,7 @@ export class SuccessFailureRedirectionConfigurerImpl<P> extends AbstractParent<P
   }
 
   async getProviders(): Promise<Provider[]> {
-    console.log('confirmation redirection urls', this.successRedirectUrl, this.failureRedirectUrl);
+    trace('confirmation redirection urls', this.successRedirectUrl, this.failureRedirectUrl);
     const providerRegistry = new SimpleProviderRegistry();
     // TODO: allow more customization
     providerRegistry.registerFactory(


### PR DESCRIPTION
affects: @zetapush/cli, @zetapush/user-management

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[x] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[x] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
If the user configures an URL for redirections, it can't benefit from automatic URLs based on the environment. For example, if the developer wants to redirect user to a particular page of its front (welcome), he has to write:
http://localhost:2999/welcome

It works only in local development. So he has to update its configuration when he wants to push.


**What is the new behavior?**
Now, if the URL is relative, the base URL is the automatic URL. If the URL is absolute, the URL is the absolute URL. For example:
/welcome
   -> in local development, it will become http://localhost:2999/welcome
   -> in push mode, it will become http://front-<env>-<app>.zetapush.com/welcome


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: