### PR TITLE
feat(cli): disable Cache-Control for served html files

### DIFF
--- a/packages/cli/src/utils/http-server.js
+++ b/packages/cli/src/utils/http-server.js
@@ -23,17 +23,25 @@ const createServer = (command, config, port) => {
       request,
       response,
       {
-        public: command.front
+        public: command.front,
+        headers: [
+          {
+            source: '*.html',
+            headers: {
+              key: 'Cache-Control',
+              value: 'no-store'
+            }
+          }
+        ]
       },
       {
         stat: (filepath) =>
-          stat(filepath).then(
-            (stats) =>
-              filepath.endsWith('.html')
-                ? Object.assign(stats, {
-                    size: stats.size + injected.length
-                  })
-                : stats
+          stat(filepath).then((stats) =>
+            filepath.endsWith('.html')
+              ? Object.assign(stats, {
+                  size: stats.size + injected.length
+                })
+              : stats
           ),
         createReadStream(filepath) {
           const stream = fs.createReadStream(filepath);


### PR DESCRIPTION
affects: @zetapush/cli

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[x] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
Served html files are cached in browser

**What is the new behavior?**
html files are now served with Cache-Control:no-store header


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: