### PR TITLE
feat(worker): update resource before each register

### DIFF
--- a/packages/worker/src/client/worker.ts
+++ b/packages/worker/src/client/worker.ts
@@ -127,6 +127,9 @@ export class WorkerClient extends Client {
   async registerWorker() {
     if (this.queue) {
       try {
+        // Worker muster be registered with a unique resource
+        this.setResource(`node_js_worker_${uuid()}`);
+        // Register worker on queue service
         this.queue.register({
           capacity: this.capacity,
           routing: {

--- a/packages/worker/src/client/worker.ts
+++ b/packages/worker/src/client/worker.ts
@@ -127,7 +127,7 @@ export class WorkerClient extends Client {
   async registerWorker() {
     if (this.queue) {
       try {
-        // Worker muster be registered with a unique resource
+        // Worker must be registered with a unique resource
         this.setResource(`node_js_worker_${uuid()}`);
         // Register worker on queue service
         this.queue.register({


### PR DESCRIPTION
affects: @zetapush/worker

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[ ] @zetapush/user-management
[x] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
Worker instance keep resource between reconnection.

**What is the new behavior?**
A new resource id is created before each register

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: