### PR TITLE
fix(user-management): improve relative URL management and add error m…

### DIFF
--- a/packages/common/spec/it/environment/default-environment-provider.spec.ts
+++ b/packages/common/spec/it/environment/default-environment-provider.spec.ts
@@ -6,7 +6,8 @@ import {
   PushedEnvironmentProvider,
   ResolvedConfig,
   ServerClient,
-  LocalServerRegistry
+  LocalServerRegistry,
+  CURRENT_WORKER_NAME
 } from '../../../src';
 import { mock, instance, when, anything } from 'ts-mockito';
 import { Environment, ZetaPushContext } from '@zetapush/core';
@@ -185,6 +186,12 @@ describe(`defaultEnvironmentProvider()`, () => {
                 it(`returns null`, async () => {
                   const { context } = await this.provider.get(instance(this.client), instance(this.queueApi));
                   expect(context.getWorkerUrl('unexisting')).toBeNull();
+                });
+              });
+              describe(`with default name and internal server`, () => {
+                it(`returns worker url from cloud for internal server`, async () => {
+                  const { context } = await this.provider.get(instance(this.client), instance(this.queueApi));
+                  expect(context.getWorkerUrl(CURRENT_WORKER_NAME, true)).toBe('http://worker.zetapush.app/@zetapush');
                 });
               });
             });

--- a/packages/common/spec/ut/environment/accessor.spec.ts
+++ b/packages/common/spec/ut/environment/accessor.spec.ts
@@ -2,148 +2,287 @@ import 'jasmine';
 import { PropertyAccessorWrapper } from '../../../src';
 
 describe(`PropertyAccessorWrapper`, () => {
-  beforeEach(() => {
-    this.obj = {
-      a: {
-        b: 3,
-        c: 4,
-        d: {
-          e: 'e'
+  describe(`(object)`, () => {
+    beforeEach(() => {
+      this.obj = {
+        a: {
+          b: 3,
+          c: 4,
+          d: {
+            e: 'e'
+          },
+          f: ['g', 'h']
         },
-        f: ['g', 'h']
-      },
-      0: 0
-    };
-    this.accessor = new PropertyAccessorWrapper(this.obj);
+        0: 0
+      };
+      this.accessor = new PropertyAccessorWrapper(this.obj);
+    });
+
+    describe(`.get()`, () => {
+      describe(`on first level key`, () => {
+        it(`returns the whole object of the first level`, async () => {
+          const value = this.accessor.get('a');
+          expect(value).toEqual(this.obj['a']);
+        });
+      });
+
+      describe(`on last level key`, () => {
+        it(`returns the value`, async () => {
+          const value = this.accessor.get('a.b');
+          expect(value).toEqual(this.obj['a']['b']);
+        });
+      });
+
+      describe(`on third level key`, () => {
+        it(`returns the value`, async () => {
+          const value = this.accessor.get('a.d.e');
+          expect(value).toEqual(this.obj['a']['d']['e']);
+        });
+      });
+
+      describe(`on key that points to an array`, () => {
+        it(`returns the array`, async () => {
+          const value = this.accessor.get('a.f');
+          expect(value).toEqual(this.obj['a']['f']);
+        });
+      });
+
+      describe(`on key that points to a value in an array`, () => {
+        it(`returns the value of the right index`, async () => {
+          const value = this.accessor.get('a.f.1');
+          expect(value).toEqual(this.obj['a']['f'][1]);
+        });
+      });
+
+      describe(`on key that points to a falsy value`, () => {
+        it(`returns the value`, async () => {
+          const value = this.accessor.get('0');
+          expect(value).toEqual(this.obj['0']);
+        });
+      });
+
+      describe(`without key`, () => {
+        it(`returns the whole object`, async () => {
+          const value = this.accessor.get('');
+          expect(value).toEqual(this.obj);
+        });
+      });
+
+      describe(`with invalid key`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('---{}[]');
+          expect(value).toBeNull();
+        });
+        it(`returns null`, async () => {
+          const value = this.accessor.get('....');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`with key that points to nothing`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('a.Z');
+          expect(value).toBeNull();
+        });
+      });
+    });
+
+    describe(`.has()`, () => {
+      describe(`on first level key`, () => {
+        it(`returns true`, async () => {
+          const value = this.accessor.has('a');
+          expect(value).toBe(true);
+        });
+      });
+
+      describe(`on last level key`, () => {
+        it(`returns true`, async () => {
+          const value = this.accessor.has('a.b');
+          expect(value).toBe(true);
+        });
+      });
+
+      describe(`on third level key`, () => {
+        it(`returns true`, async () => {
+          const value = this.accessor.has('a.d.e');
+          expect(value).toBe(true);
+        });
+      });
+
+      describe(`on key that points to an array`, () => {
+        it(`returns true`, async () => {
+          const value = this.accessor.has('a.f');
+          expect(value).toBe(true);
+        });
+      });
+
+      describe(`on key that points to a value in an array`, () => {
+        it(`returns true`, async () => {
+          const value = this.accessor.has('a.f.1');
+          expect(value).toBe(true);
+        });
+      });
+
+      describe(`without key`, () => {
+        it(`returns true`, async () => {
+          const value = this.accessor.has('');
+          expect(value).toBe(true);
+        });
+      });
+
+      describe(`with invalid key`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('---{}[]');
+          expect(value).toBe(false);
+        });
+        it(`returns false`, async () => {
+          const value = this.accessor.has('....');
+          expect(value).toBe(false);
+        });
+      });
+
+      describe(`with key that points to nothing`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('a.Z');
+          expect(value).toBe(false);
+        });
+      });
+    });
   });
+  describe(`(null)`, () => {
+    beforeEach(() => {
+      this.obj = null;
+      this.accessor = new PropertyAccessorWrapper(this.obj);
+    });
 
-  describe(`.get()`, () => {
-    describe(`on first level key`, () => {
-      it(`returns the whole object of the first level`, async () => {
-        const value = this.accessor.get('a');
-        expect(value).toEqual(this.obj['a']);
+    describe(`.get()`, () => {
+      describe(`on first level key`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('a');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`on last level key`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('a.b');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`on third level key`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('a.d.e');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`on key that points to an array`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('a.f');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`on key that points to a value in an array`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('a.f.1');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`on key that points to a falsy value`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('0');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`without key`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`with invalid key`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('---{}[]');
+          expect(value).toBeNull();
+        });
+        it(`returns null`, async () => {
+          const value = this.accessor.get('....');
+          expect(value).toBeNull();
+        });
+      });
+
+      describe(`with key that points to nothing`, () => {
+        it(`returns null`, async () => {
+          const value = this.accessor.get('a.Z');
+          expect(value).toBeNull();
+        });
       });
     });
 
-    describe(`on last level key`, () => {
-      it(`returns the value`, async () => {
-        const value = this.accessor.get('a.b');
-        expect(value).toEqual(this.obj['a']['b']);
+    describe(`.has()`, () => {
+      describe(`on first level key`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('a');
+          expect(value).toBe(false);
+        });
       });
-    });
 
-    describe(`on third level key`, () => {
-      it(`returns the value`, async () => {
-        const value = this.accessor.get('a.d.e');
-        expect(value).toEqual(this.obj['a']['d']['e']);
+      describe(`on last level key`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('a.b');
+          expect(value).toBe(false);
+        });
       });
-    });
 
-    describe(`on key that points to an array`, () => {
-      it(`returns the array`, async () => {
-        const value = this.accessor.get('a.f');
-        expect(value).toEqual(this.obj['a']['f']);
+      describe(`on third level key`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('a.d.e');
+          expect(value).toBe(false);
+        });
       });
-    });
 
-    describe(`on key that points to a value in an array`, () => {
-      it(`returns the value of the right index`, async () => {
-        const value = this.accessor.get('a.f.1');
-        expect(value).toEqual(this.obj['a']['f'][1]);
+      describe(`on key that points to an array`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('a.f');
+          expect(value).toBe(false);
+        });
       });
-    });
 
-    describe(`on key that points to a falsy value`, () => {
-      it(`returns the value`, async () => {
-        const value = this.accessor.get('0');
-        expect(value).toEqual(this.obj['0']);
+      describe(`on key that points to a value in an array`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('a.f.1');
+          expect(value).toBe(false);
+        });
       });
-    });
 
-    describe(`without key`, () => {
-      it(`returns the whole object`, async () => {
-        const value = this.accessor.get('');
-        expect(value).toEqual(this.obj);
+      describe(`without key`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('');
+          expect(value).toBe(false);
+        });
       });
-    });
 
-    describe(`with invalid key`, () => {
-      it(`returns null`, async () => {
-        const value = this.accessor.get('---{}[]');
-        expect(value).toBeNull();
+      describe(`with invalid key`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('---{}[]');
+          expect(value).toBe(false);
+        });
+        it(`returns false`, async () => {
+          const value = this.accessor.has('....');
+          expect(value).toBe(false);
+        });
       });
-      it(`returns null`, async () => {
-        const value = this.accessor.get('....');
-        expect(value).toBeNull();
-      });
-    });
 
-    describe(`with key that points to nothing`, () => {
-      it(`returns null`, async () => {
-        const value = this.accessor.get('a.Z');
-        expect(value).toBeNull();
-      });
-    });
-  });
-
-  describe(`.has()`, () => {
-    describe(`on first level key`, () => {
-      it(`returns true`, async () => {
-        const value = this.accessor.has('a');
-        expect(value).toBe(true);
-      });
-    });
-
-    describe(`on last level key`, () => {
-      it(`returns true`, async () => {
-        const value = this.accessor.has('a.b');
-        expect(value).toBe(true);
-      });
-    });
-
-    describe(`on third level key`, () => {
-      it(`returns true`, async () => {
-        const value = this.accessor.has('a.d.e');
-        expect(value).toBe(true);
-      });
-    });
-
-    describe(`on key that points to an array`, () => {
-      it(`returns true`, async () => {
-        const value = this.accessor.has('a.f');
-        expect(value).toBe(true);
-      });
-    });
-
-    describe(`on key that points to a value in an array`, () => {
-      it(`returns true`, async () => {
-        const value = this.accessor.has('a.f.1');
-        expect(value).toBe(true);
-      });
-    });
-
-    describe(`without key`, () => {
-      it(`returns true`, async () => {
-        const value = this.accessor.has('');
-        expect(value).toBe(true);
-      });
-    });
-
-    describe(`with invalid key`, () => {
-      it(`returns false`, async () => {
-        const value = this.accessor.has('---{}[]');
-        expect(value).toBe(false);
-      });
-      it(`returns false`, async () => {
-        const value = this.accessor.has('....');
-        expect(value).toBe(false);
-      });
-    });
-
-    describe(`with key that points to nothing`, () => {
-      it(`returns false`, async () => {
-        const value = this.accessor.has('a.Z');
-        expect(value).toBe(false);
+      describe(`with key that points to nothing`, () => {
+        it(`returns false`, async () => {
+          const value = this.accessor.has('a.Z');
+          expect(value).toBe(false);
+        });
       });
     });
   });

--- a/packages/common/src/environment/accessor.ts
+++ b/packages/common/src/environment/accessor.ts
@@ -5,9 +5,12 @@ export class PropertyAccessorWrapper {
     if (!prop) {
       return !!this.obj;
     }
-    const parts = this.parts(prop);
     let current = this.obj;
+    const parts = this.parts(prop);
     for (let part of parts) {
+      if (current === null || typeof current === 'undefined') {
+        return false;
+      }
       if (!(part in current)) {
         return false;
       }
@@ -20,9 +23,12 @@ export class PropertyAccessorWrapper {
     if (!prop) {
       return this.obj;
     }
-    const parts = this.parts(prop);
     let current = this.obj;
+    const parts = this.parts(prop);
     for (let part of parts) {
+      if (current === null || typeof current === 'undefined') {
+        return current;
+      }
       if (!(part in current)) {
         return null;
       }

--- a/packages/common/src/environment/platform-event-context.ts
+++ b/packages/common/src/environment/platform-event-context.ts
@@ -46,7 +46,7 @@ export class PlatformEventContext implements ZetaPushContext, Loadable {
   }
 
   getFrontUrl(name?: string): string | null {
-    console.log('==> get front url : ', this.context);
+    trace(`getFrontUrl(${name || ''})`, this.context);
     this.checkLoaded();
     return this.getUrl(ServerType.FRONT, this.context!.fronts, name);
   }
@@ -55,13 +55,17 @@ export class PlatformEventContext implements ZetaPushContext, Loadable {
     this.checkLoaded();
     const url = this.getUrl(ServerType.WORKER, this.context!.workers, name);
     if (!url) {
+      trace(`getWorkerUrl(${name || ''}, ${zetapushInternalServer})`, this.context, 'empty url');
       return url;
     }
     // when run in cloud, the base URL is the same
     // to distinguish between HTTP servers, we use routing paths
     if (zetapushInternalServer) {
-      return this.zetapushInternalUrlProvider(url);
+      const internalServerUrl = this.zetapushInternalUrlProvider(url);
+      trace(`getWorkerUrl(${name || ''}, ${zetapushInternalServer})`, this.context, internalServerUrl);
+      return internalServerUrl;
     }
+    trace(`getWorkerUrl(${name || ''}, ${zetapushInternalServer})`, this.context, url);
     return url;
   }
 

--- a/packages/user-management/spec/it/common/utils/evaluate.spec.ts
+++ b/packages/user-management/spec/it/common/utils/evaluate.spec.ts
@@ -1,0 +1,123 @@
+import 'jasmine';
+import {
+  VariableEvaluator,
+  EvaluatorMissingKeyHandlerBuilder,
+  MissingKeyError
+} from '../../../../src/common/utils/evaluate';
+
+describe(`VariableEvaluator.evaluate()`, () => {
+  describe(`configured to fail on missing property`, () => {
+    beforeEach(() => {
+      const missingKeyHandler = new EvaluatorMissingKeyHandlerBuilder()
+        /**/ .error((key) => `Missing key ${key}`)
+        /**/ .build();
+      this.evaluator = new VariableEvaluator(missingKeyHandler);
+    });
+
+    describe(`called with missing key`, () => {
+      it(`throws an error with the configured message`, async () => {
+        expect(() => {
+          this.evaluator.evaluate('/users/${accountId}/token/${token}', { foo: 1234, bar: 'abc' });
+        }).toThrowError(MissingKeyError, 'Missing key accountId');
+      });
+    });
+
+    describe(`called on null context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        expect(() => {
+          this.evaluator.evaluate('/users/${accountId}/token/${token}', null);
+        }).toThrowError(MissingKeyError, 'Missing key accountId');
+      });
+    });
+
+    describe(`called on undefined context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        expect(() => {
+          this.evaluator.evaluate('/users/${accountId}/token/${token}', undefined);
+        }).toThrowError(MissingKeyError, 'Missing key accountId');
+      });
+    });
+
+    describe(`called on empy context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        expect(() => {
+          this.evaluator.evaluate('/users/${accountId}/token/${token}', {});
+        }).toThrowError(MissingKeyError, 'Missing key accountId');
+      });
+    });
+  });
+
+  describe(`configured to ignore missing property`, () => {
+    beforeEach(() => {
+      const missingKeyHandler = new EvaluatorMissingKeyHandlerBuilder()
+        /**/ .ignore()
+        /**/ .build();
+      this.evaluator = new VariableEvaluator(missingKeyHandler);
+    });
+
+    describe(`called with missing key`, () => {
+      it(`evaluates as empty string`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', { foo: 1234, bar: 'abc' });
+        expect(evaluated).toBe('/users//token/');
+      });
+    });
+
+    describe(`called on null context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', null);
+        expect(evaluated).toBe('/users//token/');
+      });
+    });
+
+    describe(`called on undefined context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', undefined);
+        expect(evaluated).toBe('/users//token/');
+      });
+    });
+
+    describe(`called on empy context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', {});
+        expect(evaluated).toBe('/users//token/');
+      });
+    });
+  });
+
+  describe(`configured to provide default value on missing property`, () => {
+    beforeEach(() => {
+      const missingKeyHandler = new EvaluatorMissingKeyHandlerBuilder()
+        /**/ .defaultValue((key) => (key === 'accountId' ? '1234' : 'abc'))
+        /**/ .build();
+      this.evaluator = new VariableEvaluator(missingKeyHandler);
+    });
+
+    describe(`called with missing key`, () => {
+      it(`evaluates as empty string`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', { foo: 1234, bar: 'abc' });
+        expect(evaluated).toBe('/users/1234/token/abc');
+      });
+    });
+
+    describe(`called on null context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', null);
+        expect(evaluated).toBe('/users/1234/token/abc');
+      });
+    });
+
+    describe(`called on undefined context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', undefined);
+        expect(evaluated).toBe('/users/1234/token/abc');
+      });
+    });
+
+    describe(`called on empy context`, () => {
+      it(`throws an error with the configured message`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', {});
+        expect(evaluated).toBe('/users/1234/token/abc');
+      });
+    });
+  });
+});

--- a/packages/user-management/spec/it/standard-user-workflow/core/account/StandardResetPassword.spec.ts
+++ b/packages/user-management/spec/it/standard-user-workflow/core/account/StandardResetPassword.spec.ts
@@ -75,7 +75,7 @@ describe(`StandardResetPassword`, () => {
         this.properties = mock(MockedConfigurationProperties);
         this.zetapushContext = mock(MockedZetaPushContext);
         when(this.zetapushContext.getLocalZetaPushHttpPort()).thenReturn(2999);
-        when(this.properties.get(ResetPasswordPropertiesKeys.BaseUrl, anyString())).thenReturn('http://locahost:8000');
+        when(this.properties.get(ResetPasswordPropertiesKeys.AskUrl, anyString())).thenReturn('http://locahost:8000');
         when(this.zetapushContext.getFrontUrl()).thenReturn('http://locahost:8000');
         await given()
           .credentials()

--- a/packages/user-management/spec/ut/common/utils/absolutize.spec.ts
+++ b/packages/user-management/spec/ut/common/utils/absolutize.spec.ts
@@ -1,0 +1,95 @@
+import 'jasmine';
+import {
+  absolutize,
+  DefaultRelativeUrlError,
+  MissingBaseUrlError,
+  InvalidUrlError
+} from '../../../../src/common/utils/url';
+
+describe(`absolutize()`, () => {
+  describe(`with base url`, () => {
+    describe(`and no configured url`, () => {
+      it(`uses the default path`, async () => {
+        const url = absolutize(null, 'http://base-url', '#default', 'front', 'configuration.key');
+        expect(url).toBe('http://base-url/#default');
+      });
+    });
+
+    describe(`and empty configured url`, () => {
+      it(`uses the base url`, async () => {
+        const url = absolutize('', 'http://base-url', '#default', 'front', 'configuration.key');
+        expect(url).toBe('http://base-url/');
+      });
+    });
+
+    describe(`and a configured relative url`, () => {
+      it(`concats relative url to base url`, async () => {
+        const url = absolutize('relative/url', 'http://base-url', '#default', 'front', 'configuration.key');
+        expect(url).toBe('http://base-url/relative/url');
+      });
+    });
+
+    describe(`and a configured absolute url`, () => {
+      it(`uses the configured url`, async () => {
+        const url = absolutize('http://absolute/url', 'http://base-url', '#default', 'front', 'configuration.key');
+        expect(url).toBe('http://absolute/url');
+      });
+    });
+
+    describe(`and an invalid configured absolute url`, () => {
+      it(`throw a error indicating that URL is not valid`, async () => {
+        expect(() => {
+          absolutize('http://invalid%url', 'http://base-url', '#default', 'front', 'configuration.key');
+        }).toThrowError(InvalidUrlError);
+      });
+    });
+
+    describe(`containing path`, () => {
+      it(`uses the path and the default path`, async () => {
+        const url = absolutize(null, 'http://base-url/p/a/t/h', '/default', 'front', 'configuration.key');
+        expect(url).toBe('http://base-url/p/a/t/h/default');
+      });
+    });
+  });
+
+  describe(`without base url`, () => {
+    describe(`and no configured url`, () => {
+      it(`throws an error to indicate that automatic mechanism can't provide URL`, async () => {
+        expect(() => {
+          absolutize(null, null, '#default', 'front', 'configuration.key');
+        }).toThrowError(DefaultRelativeUrlError);
+      });
+    });
+
+    describe(`and empty configured url`, () => {
+      it(`throws an error to indicate that automatic mechanism can't provide URL`, async () => {
+        expect(() => {
+          absolutize('', null, '#default', 'front', 'configuration.key');
+        }).toThrowError(MissingBaseUrlError);
+      });
+    });
+
+    describe(`and a configured relative url`, () => {
+      it(`throws an error to indicate that automatic mechanism can't provide URL`, async () => {
+        expect(() => {
+          absolutize('relative/url', null, '#default', 'front', 'configuration.key');
+        }).toThrowError(MissingBaseUrlError);
+      });
+    });
+
+    describe(`and a configured absolute url`, () => {
+      it(`uses the configured url`, async () => {
+        const url = absolutize('http://absolute/url', null, '#default', 'front', 'configuration.key');
+        expect(url).toBe('http://absolute/url');
+      });
+    });
+
+    describe(`and an invalid configured absolute url`, () => {
+      it(`throw a error indicating that URL is not valid`, async () => {
+        expect(() => {
+          absolutize('http://invalid%url', null, '#default', 'front', 'configuration.key');
+        }).toThrowError(MissingBaseUrlError);
+      });
+    });
+  });
+});

--- a/packages/user-management/spec/ut/common/utils/evaluate.spec.ts
+++ b/packages/user-management/spec/ut/common/utils/evaluate.spec.ts
@@ -1,0 +1,64 @@
+import 'jasmine';
+import { VariableEvaluator, EvaluatorMissingKeyHandlerBuilder } from '../../../../src/common/utils/evaluate';
+
+describe(`VariableEvaluator.evaluate()`, () => {
+  describe(`on existing property`, () => {
+    beforeEach(() => {
+      this.evaluator = new VariableEvaluator();
+    });
+
+    describe(`and object context`, () => {
+      it(`evaluates the property value`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}', { accountId: 1234 });
+        expect(evaluated).toBe('/users/1234');
+      });
+    });
+
+    describe(`and nested object context`, () => {
+      it(`evaluates the nested property value`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${account.accountId}', { account: { accountId: 1234 } });
+        expect(evaluated).toBe('/users/1234');
+      });
+    });
+
+    describe(`and nested array context`, () => {
+      it(`evaluates the value at the index`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${0}', [1234]);
+        expect(evaluated).toBe('/users/1234');
+      });
+    });
+  });
+
+  describe(`on several existing properties`, () => {
+    beforeEach(() => {
+      this.evaluator = new VariableEvaluator();
+    });
+
+    describe(`and object context`, () => {
+      it(`evaluates the property value`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${accountId}/token/${token}', {
+          accountId: 1234,
+          token: 'abc'
+        });
+        expect(evaluated).toBe('/users/1234/token/abc');
+      });
+    });
+
+    describe(`and nested object context`, () => {
+      it(`evaluates the nested property value`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${account.accountId}/token/${token.value}', {
+          account: { accountId: 1234 },
+          token: { value: 'abc' }
+        });
+        expect(evaluated).toBe('/users/1234/token/abc');
+      });
+    });
+
+    describe(`and nested array context`, () => {
+      it(`evaluates the value at the index`, async () => {
+        const evaluated = this.evaluator.evaluate('/users/${0}/token/${1}', [1234, 'abc']);
+        expect(evaluated).toBe('/users/1234/token/abc');
+      });
+    });
+  });
+});

--- a/packages/user-management/src/common/utils/evaluate.ts
+++ b/packages/user-management/src/common/utils/evaluate.ts
@@ -1,0 +1,85 @@
+import { PropertyAccessorWrapper, BaseError } from '@zetapush/common';
+import { IllegalStateError } from '../api';
+
+export class MissingKeyError extends BaseError {
+  constructor(message: string, public readonly key: string, public readonly context: any, cause?: Error) {
+    super(message, cause);
+  }
+}
+
+export class EvaluatorMissingKeyHandlerBuilder {
+  private errorMsgBuilder?: (key: string, context: any) => string;
+  private defaultValueBuilder?: (key: string, context: any) => string;
+
+  /**
+   * If a key is missing then generate an error message and throw an exception.
+   *
+   * @param message either a message or a function that provides a
+   * message according to the key and the evaluation context
+   */
+  error(message: string): this;
+  error(messageProvider: (key: string, context: any) => string): this;
+  error(messageBuilder: any): this {
+    if (typeof messageBuilder === 'string') {
+      this.errorMsgBuilder = (key: string, context: any) => messageBuilder;
+    } else {
+      this.errorMsgBuilder = messageBuilder;
+    }
+    return this;
+  }
+
+  /**
+   * If a key is missing, then an empty string is used in place.
+   */
+  ignore(): this {
+    this.defaultValueBuilder = () => '';
+    return this;
+  }
+
+  /**
+   * If a key is missing then replace by a string value.
+   *
+   * @param value either a value or a function that provides a
+   * value according to the key and the context.
+   */
+  defaultValue(value: string): this;
+  defaultValue(valueProvider: (key: string, context: any) => string): this;
+  defaultValue(valueBuilder: any): this {
+    if (typeof valueBuilder === 'string') {
+      this.defaultValueBuilder = (key: string, context: any) => valueBuilder;
+    } else {
+      this.defaultValueBuilder = valueBuilder;
+    }
+    return this;
+  }
+
+  build(): (key: string, context: any) => string {
+    if (this.defaultValueBuilder) {
+      return this.defaultValueBuilder;
+    }
+    if (this.errorMsgBuilder) {
+      return (key: string, context: any) => {
+        throw new MissingKeyError(this.errorMsgBuilder!(key, context), key, context);
+      };
+    }
+    throw new IllegalStateError(`You need to indicate which behavior before calling build`);
+  }
+}
+
+export const failOnMissingKeyHandler = (key: string, context: any): string => {
+  throw new MissingKeyError(`Can't access property ${key}`, key, context);
+};
+
+export class VariableEvaluator {
+  constructor(private missingKeyHandler = failOnMissingKeyHandler) {}
+
+  evaluate(str: string, context: any) {
+    const accessor = new PropertyAccessorWrapper(context);
+    return str.replace(/\$\{([^}]+)\}/g, (_, key) => {
+      if (accessor.has(key)) {
+        return accessor.get(key);
+      }
+      return this.missingKeyHandler(key, context);
+    });
+  }
+}

--- a/packages/user-management/src/common/utils/url.ts
+++ b/packages/user-management/src/common/utils/url.ts
@@ -1,0 +1,92 @@
+import { URL } from 'url';
+
+import { BaseError } from '@zetapush/common';
+
+export abstract class UrlError extends BaseError {
+  constructor(
+    message: string,
+    public readonly fragmentName: string,
+    public readonly configurationKey: string,
+    cause?: Error
+  ) {
+    super(message, cause);
+  }
+}
+
+export class DefaultRelativeUrlError extends UrlError {
+  constructor(message: string, fragmentName: string, configurationKey: string, cause?: Error) {
+    super(message, fragmentName, configurationKey, cause);
+  }
+}
+
+export class MissingBaseUrlError extends UrlError {
+  constructor(message: string, fragmentName: string, configurationKey: string, cause?: Error) {
+    super(message, fragmentName, configurationKey, cause);
+  }
+}
+
+export class InvalidUrlError extends UrlError {
+  constructor(message: string, fragmentName: string, configurationKey: string, cause?: Error) {
+    super(message, fragmentName, configurationKey, cause);
+  }
+}
+
+export const absolutize = (
+  url: string | null,
+  baseUrl: string | null,
+  defaultPath: string,
+  what: string,
+  configurationKey: string
+): string => {
+  let relativeUrl = url;
+  if (relativeUrl === null) {
+    relativeUrl = defaultPath;
+  }
+  // no matching front/worker handled by ZetaPush
+  // and no explicit URL configured (using default path)
+  if (!baseUrl && relativeUrl === defaultPath) {
+    throw new DefaultRelativeUrlError(
+      `You didn't provide any URL for ${configurationKey}, so the default relative path is used (${defaultPath}).
+    It seems that there is no ${what} started. Mechanism that automatically provides URLs can't provide valid URL for ${what}.
+
+    You need to either start ${what} or to provide an explicit and absolute URL for ${configurationKey}`,
+      what,
+      configurationKey
+    );
+  }
+  try {
+    let absoluteUrl = join(relativeUrl, baseUrl || undefined);
+    return absoluteUrl.toString();
+  } catch (e) {
+    // not a valid URL, maybe because it is relative
+    // and no matching front/worker handled by ZetaPush
+    // => still relative at the end so it is not valid
+    if (baseUrl === null || baseUrl === '') {
+      throw new MissingBaseUrlError(
+        `It seems that there is no ${what} started. Mechanism that automatically provides URLs can't provide valid URL for ${what}.
+
+      You need to either start ${what} or to provide an explicit and absolute URL for ${configurationKey}`,
+        what,
+        configurationKey,
+        e
+      );
+    }
+    throw new InvalidUrlError(
+      `The URL for ${configurationKey} provided in configuration is not valid`,
+      what,
+      configurationKey,
+      e
+    );
+  }
+};
+
+export const join = (url: string, baseUrl?: string) => {
+  if (isAbsolute(url)) {
+    return new URL(url).toString();
+  }
+  return new URL((baseUrl || '') + url).toString();
+};
+
+export const isAbsolute = (url: string) => {
+  return /^(?:[a-z]+:)?\/\//i.test(url);
+};

--- a/packages/user-management/src/standard-user-workflow/configurer/properties.ts
+++ b/packages/user-management/src/standard-user-workflow/configurer/properties.ts
@@ -8,15 +8,14 @@ export enum EmailPropertyKeys {
 }
 
 export enum RegistrationConfirmationPropertyKeys {
-  BaseUrl = 'registration.confirmation.base-url',
   EmailFrom = 'registration.confirmation.email.from',
   EmailSubject = 'registration.confirmation.email.subject',
+  AccountConfirmationUrl = 'registration.confirmation.confirm-url',
   AccountConfirmedRedirectionUrl = 'registration.confirmation.success-url',
   AccountConfirmationFailedRedirectionUrl = 'registration.confirmation.failure-url'
 }
 
 export enum ResetPasswordPropertiesKeys {
-  BaseUrl = 'reset-password.ask.base-url',
   AskUrl = 'reset-password.ask.url',
   EmailFrom = 'reset-password.ask.email.from',
   EmailSubject = 'reset-password.ask.email.subject'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Scope** (check one with "x")
```
[ ] <root>
[ ] @zetapush/cli
[ ] @zetapush/client
[ ] @zetapush/cometd
[ ] @zetapush/common
[ ] @zetapush/core
[ ] @zetapush/create
[ ] @zetapush/http-server
[ ] @zetapush/platform-legacy
[ ] @zetapush/testing
[ ] @zetapush/troubleshooting
[x] @zetapush/user-management
[ ] @zetapush/worker
```

**What is the current behavior?** (You can also link to an open issue here)
When the user provides a relative URL in configuration, it is concatenated to the URL that is
automatically provided by ZetaPush according to run environment.
In previous version, some URLs were
not totally compliant with this system.
Moreover, there are some cases where the URLs adaptated to
the run environment can't be automatically provided (for example in local when the front is not
started). In this case, an explicit error indicates that the front must be started to benefit from
automatic URLs or to explicitly provide an absolute URL.


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

'registration.confirmation.base-url' and 'reset-password.ask.base-url' have been removed. Please use
'registration.confirmation.confirm-url' and 'registration.confirmation.confirm-url' instead

**Other information**: